### PR TITLE
feat: 백엔드에서의 Chessboard 이동 규칙 검증을 위한 `class Chessboard` 추가

### DIFF
--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Bishop.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Bishop.java
@@ -1,0 +1,86 @@
+package com.example.chessdotnet.service.chessGameSession;
+
+import java.util.LinkedList;
+
+
+/**
+ * Bishop class of chess piece
+ */
+public class Bishop extends Piece {
+    /**
+     * default constructor
+     *
+     * @param position position in chessboard.
+     * @param pieceColor color (maybe WHITE or BLACK) of this.
+     * @param chessboard chessboard where this piece exists.
+     */
+    public Bishop(ChessboardPos position, PieceColor pieceColor, Chessboard chessboard) {
+        super(position, pieceColor, chessboard);
+    }
+
+    /**
+     * return its name(typename of piece)
+     *
+     * @return typename of piece
+     */
+    @Override
+    public String toString() {
+        return "Bishop";
+    }
+
+    /**
+     * check is it Empty Square (Not a Piece)
+     * Must be overridden
+     *
+     * @return true if it is empty square
+     */
+    @Override
+    public boolean isEmptySquare() {
+        return false;
+    }
+
+    /**
+     * Get its possible destinations of its legal moves.
+     *
+     * @return LinkedList of ChessboardPos which contains possible destinations of its legal moves.
+     */
+    @Override
+    public LinkedList<ChessboardPos> getDestinations() {
+        LinkedList<ChessboardPos> dests = new LinkedList<>();
+
+        addSquaresInDirection(dests, new ChessboardPos(1, 1));
+        addSquaresInDirection(dests, new ChessboardPos(1, -1));
+        addSquaresInDirection(dests, new ChessboardPos(-1, 1));
+        addSquaresInDirection(dests, new ChessboardPos(-1, -1));
+
+        return dests;
+    }
+
+    /**
+     * update its position and chessboard, if dest is reachable in one move by itself.
+     * It is a safe way to update chessboard, maintaining coherency between `piece.position`
+     * and actual position in chessboard.
+     *
+     * @param dest destination of move to test
+     * @return true if and only if position updated.
+     */
+    @Override
+    public boolean testAndMove(ChessboardPos dest) {
+        //noinspection DuplicatedCode
+        ChessboardPos diff = ChessboardPos.sub(this.position, dest);
+        /* `diff.row == 0` is needed to check dest equals to this.position */
+        if (Math.abs(diff.row) != Math.abs(diff.col) || diff.row == 0)
+            return false;
+
+        /* make them into 1 or -1 */
+        diff.row = diff.row / Math.abs(diff.row);
+        diff.col = diff.col / Math.abs(diff.col);
+
+        if (checkPosInDirection(dest, diff)) {
+            chessboard.movePiece(this.position, dest);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Bishop.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Bishop.java
@@ -8,20 +8,20 @@ import java.util.LinkedList;
  */
 public class Bishop extends Piece {
     /**
-     * default constructor
+     * Default constructor
      *
-     * @param position position in chessboard.
-     * @param pieceColor color (maybe WHITE or BLACK) of this.
-     * @param chessboard chessboard where this piece exists.
+     * @param position Position in chessboard.
+     * @param pieceColor Color (maybe WHITE or BLACK) of this.
+     * @param chessboard Chessboard where this piece exists.
      */
     public Bishop(ChessboardPos position, PieceColor pieceColor, Chessboard chessboard) {
         super(position, pieceColor, chessboard);
     }
 
     /**
-     * return its name(typename of piece)
+     * Return its name(typename of piece)
      *
-     * @return typename of piece
+     * @return Typename of piece
      */
     @Override
     public String toString() {
@@ -29,10 +29,10 @@ public class Bishop extends Piece {
     }
 
     /**
-     * check is it Empty Square (Not a Piece)
+     * Check is it Empty Square (Not a Piece)
      * Must be overridden
      *
-     * @return true if it is empty square
+     * @return True if it is empty square
      */
     @Override
     public boolean isEmptySquare() {
@@ -57,12 +57,12 @@ public class Bishop extends Piece {
     }
 
     /**
-     * update its position and chessboard, if dest is reachable in one move by itself.
+     * Update its position and chessboard, if dest is reachable in one move by itself.
      * It is a safe way to update chessboard, maintaining coherency between `piece.position`
      * and actual position in chessboard.
      *
-     * @param dest destination of move to test
-     * @return true if and only if position updated.
+     * @param dest Destination of move to test
+     * @return True if and only if position updated.
      */
     @Override
     public boolean testAndMove(ChessboardPos dest) {

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Bishop.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Bishop.java
@@ -67,7 +67,7 @@ public class Bishop extends Piece {
     @Override
     public boolean testAndMove(ChessboardPos dest) {
         //noinspection DuplicatedCode
-        ChessboardPos diff = ChessboardPos.sub(this.position, dest);
+        ChessboardPos diff = ChessboardPos.sub(dest, position);
         /* `diff.row == 0` is needed to check dest equals to this.position */
         if (Math.abs(diff.row) != Math.abs(diff.col) || diff.row == 0)
             return false;
@@ -77,7 +77,10 @@ public class Bishop extends Piece {
         diff.col = diff.col / Math.abs(diff.col);
 
         if (checkPosInDirection(dest, diff)) {
-            chessboard.movePiece(this.position, dest);
+            chessboard.movePiece(new ChessboardMove(
+                    new ChessboardPos(this.position),
+                    new ChessboardPos(dest)
+            ));
             return true;
         }
 

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Chessboard.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Chessboard.java
@@ -1,0 +1,129 @@
+package com.example.chessdotnet.service.chessGameSession;
+
+
+import org.springframework.util.Assert;
+
+import java.util.LinkedList;
+
+/**
+ * Chessboard class used by `ChessGameSession`.
+ * Its data may only be handled by Pieces. (By `testAndMove()`)
+ */
+public class Chessboard {
+    /**
+     * chessboard of game. 8x8 grid of Pieces.
+     */
+    private Piece[][] chessboard;
+
+    /**
+     * Piece which moved at latest move.
+     * If there's no move in history, it is `null`.
+     */
+    public Piece nullable_lastMoved;
+
+    /**
+     * Piece color which represents that which side has turn now.
+     */
+    public Piece.PieceColor turn;
+
+    /**
+     * Records of moves. (History of moves)
+     */
+    public LinkedList<ChessboardMove> moveRecords;
+
+    /**
+     * get piece in the square, `chessboard[row][col]`.
+     * Caller must check if coordinate is valid.
+     *
+     * @param row row index of board.
+     * @param col cow index of board.
+     * @return piece in the square at given coordinate.
+     */
+    public Piece getPiece(int row, int col) {
+        Assert.isTrue(ChessboardPos.isValid(row, col), "Chessboard::getPiece() invalid arguments");
+        return chessboard[row][col];
+    }
+
+    /**
+     * get piece at given coordinate, `pos`
+     * Caller must check if coordinate is valid.
+     *
+     * @param pos coordinate in chessboard
+     * @return piece in the square at given coordinate.
+     */
+    public Piece getPiece(ChessboardPos pos) {
+        Assert.isTrue(pos.isValid(), "Chessboard::getPiece() invalid arguments");
+        return chessboard[pos.row][pos.col];
+    }
+
+    /**
+     * move a piece to dest in given coordinate.
+     * It is a safe way to update chessboard, maintaining coherency between chessboard and pieces.
+     *
+     * @param src a coordinate of a piece which wants to move
+     * @param dest a coordinate of a destination
+     * @return `this` Chessboard instance
+     */
+    public Chessboard movePiece(ChessboardPos src, ChessboardPos dest) {
+        chessboard[dest.row][dest.col] = chessboard[src.row][src.col];
+        chessboard[src.row][src.col] = new Piece(new ChessboardPos(src), Piece.PieceColor.NONE, this);
+
+        chessboard[dest.row][dest.col].position = new ChessboardPos(dest);
+        chessboard[dest.row][dest.col].hasMoved = true;
+
+        nullable_lastMoved = chessboard[dest.row][dest.col];
+
+        moveRecords.add(new ChessboardMove(new ChessboardPos(src), new ChessboardPos(dest)));
+
+        if (turn == Piece.PieceColor.BLACK) {
+            turn = Piece.PieceColor.WHITE;
+        } else {
+            turn = Piece.PieceColor.BLACK;
+        }
+        return this;
+    }
+
+    /**
+     * constructor to generate initial state of chessboard
+     */
+    public Chessboard() {
+        final int BOARD_SIZE = 8;
+        chessboard = new Piece[BOARD_SIZE][BOARD_SIZE];
+
+        chessboard[0][0] = new Rook(new ChessboardPos(0, 0), Piece.PieceColor.BLACK, this);
+        chessboard[0][1] = new Knight(new ChessboardPos(0, 1), Piece.PieceColor.BLACK, this);
+        chessboard[0][2] = new Bishop(new ChessboardPos(0, 2), Piece.PieceColor.BLACK, this);
+        chessboard[0][3] = new Queen(new ChessboardPos(0, 3), Piece.PieceColor.BLACK, this);
+        chessboard[0][4] = new King(new ChessboardPos(0, 4), Piece.PieceColor.BLACK, this);
+        chessboard[0][5] = new Bishop(new ChessboardPos(0, 5), Piece.PieceColor.BLACK, this);
+        chessboard[0][6] = new Knight(new ChessboardPos(0, 6), Piece.PieceColor.BLACK, this);
+        chessboard[0][7] = new Rook(new ChessboardPos(0, 7), Piece.PieceColor.BLACK, this);
+
+        for (int i = 0; i < BOARD_SIZE; i++) {
+            chessboard[1][i] = new Pawn(new ChessboardPos(1, i), Piece.PieceColor.BLACK, this, new ChessboardPos(1, 0));
+        }
+
+        chessboard[7][0] = new Rook(new ChessboardPos(7, 0), Piece.PieceColor.WHITE, this);
+        chessboard[7][1] = new Knight(new ChessboardPos(7, 1), Piece.PieceColor.WHITE, this);
+        chessboard[7][2] = new Bishop(new ChessboardPos(7, 2), Piece.PieceColor.WHITE, this);
+        chessboard[7][3] = new Queen(new ChessboardPos(7, 3), Piece.PieceColor.WHITE, this);
+        chessboard[7][4] = new King(new ChessboardPos(7, 4), Piece.PieceColor.WHITE, this);
+        chessboard[7][5] = new Bishop(new ChessboardPos(7, 5), Piece.PieceColor.WHITE, this);
+        chessboard[7][6] = new Knight(new ChessboardPos(7, 6), Piece.PieceColor.WHITE, this);
+        chessboard[7][7] = new Rook(new ChessboardPos(7, 7), Piece.PieceColor.WHITE, this);
+
+        for (int i = 0; i < BOARD_SIZE; i++) {
+            chessboard[6][i] = new Pawn(new ChessboardPos(6, i), Piece.PieceColor.WHITE, this, new ChessboardPos(-1, 0));
+        }
+
+        for (int row = 2; row <= 5; row++) {
+            for (int col = 0; col < BOARD_SIZE; col++) {
+                chessboard[row][col] = new Piece(new ChessboardPos(row, col), Piece.PieceColor.NONE, this);
+            }
+        }
+
+        nullable_lastMoved = null;
+        turn = Piece.PieceColor.WHITE;
+        moveRecords = new LinkedList<>();
+    }
+}

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Chessboard.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Chessboard.java
@@ -1,6 +1,7 @@
 package com.example.chessdotnet.service.chessGameSession;
 
 
+import org.springframework.data.util.Pair;
 import org.springframework.util.Assert;
 
 import java.util.LinkedList;
@@ -13,7 +14,7 @@ public class Chessboard {
     /**
      * Chessboard of game. 8x8 grid of Pieces.
      */
-    private Piece[][] chessboard;
+    protected Piece[][] chessboard;
 
     /**
      * Piece which moved at latest move.
@@ -30,6 +31,16 @@ public class Chessboard {
      * Records of moves. (History of moves)
      */
     public LinkedList<ChessboardMove> moveRecords;
+
+    /**
+     * White's King.
+     */
+    public King whiteKing;
+
+    /**
+     * Black's King.
+     */
+    public King blackKing;
 
     /**
      * Get piece in the square, `chessboard[row][col]`.
@@ -60,10 +71,12 @@ public class Chessboard {
      * Move a piece to dest in given coordinate.
      * It is a safe way to update chessboard, maintaining coherency between chessboard and pieces.
      *
-     * @param src A coordinate of a piece which wants to move
-     * @param dest A coordinate of a destination
+     * @param move Move information.
      */
-    public void movePiece(ChessboardPos src, ChessboardPos dest) {
+    public void movePiece(ChessboardMove move) {
+        ChessboardPos src = move.startPosition;
+        ChessboardPos dest = move.endPosition;
+
         chessboard[dest.row][dest.col] = chessboard[src.row][src.col];
         chessboard[src.row][src.col] = new Piece(new ChessboardPos(src), Piece.PieceColor.NONE, this);
 
@@ -72,40 +85,168 @@ public class Chessboard {
 
         nullable_lastMoved = chessboard[dest.row][dest.col];
 
-        moveRecords.add(new ChessboardMove(new ChessboardPos(src), new ChessboardPos(dest)));
+        moveRecords.add(move);
 
         if (turnNow == Piece.PieceColor.BLACK) {
             turnNow = Piece.PieceColor.WHITE;
         } else {
             turnNow = Piece.PieceColor.BLACK;
         }
+
+        if (!move.isSpecialMove()) return;
+
+        /* There's more need to be done, if it is a special move.
+         * If it is castling, need to move Rook.
+         * If it is en passant, need to remove the pawn taken by it.
+         * If it is promotion, need to replace that pawn into another.
+         */
+
+        if (move.isCastling()) {
+            ChessboardPos castleDirection = ChessboardPos.sub(dest, src);
+            int colOfRook;
+            if (castleDirection.col > 0) {
+                colOfRook = 7;
+            } else {
+                colOfRook = 0;
+            }
+
+            int rowOfRook = dest.row;
+
+            ChessboardPos newPosOfRook = new ChessboardPos(
+                    rowOfRook,
+                    castleDirection.col > 0 ? dest.col - 1 : dest.col + 1
+            );
+
+            chessboard[newPosOfRook.row][newPosOfRook.col] = chessboard[rowOfRook][colOfRook];
+            chessboard[newPosOfRook.row][newPosOfRook.col].position = new ChessboardPos(newPosOfRook.row, newPosOfRook.col);
+            chessboard[rowOfRook][colOfRook] = new Piece(
+                    new ChessboardPos(rowOfRook, colOfRook),
+                    Piece.PieceColor.NONE,
+                    this
+            );
+            chessboard[rowOfRook][colOfRook].hasMoved = true;
+        }
+
+        Pair<Boolean, Piece.PieceType> promotionInfo = move.getPromotionInfo();
+        if (promotionInfo.getFirst()) {
+            Piece newPiece = null;
+            switch (promotionInfo.getSecond()) {
+                case QUEEN ->
+                    newPiece = new Queen(new ChessboardPos(dest), getPiece(dest).pieceColor, this);
+                case ROOK ->
+                    newPiece = new Rook(new ChessboardPos(dest), getPiece(dest).pieceColor, this);
+                case BISHOP ->
+                    newPiece = new Bishop(new ChessboardPos(dest), getPiece(dest).pieceColor, this);
+                case KNIGHT ->
+                    newPiece = new Knight(new ChessboardPos(dest), getPiece(dest).pieceColor, this);
+            }
+            Assert.isTrue(newPiece != null, "Received promotionInfo is wrong");
+            chessboard[dest.row][dest.col] = newPiece;
+            chessboard[dest.row][dest.col].hasMoved = true;
+            nullable_lastMoved = chessboard[dest.row][dest.col];
+        }
+
+        Pair<Boolean, ChessboardPos> enPassantInfo = move.getEnPassantInfo();
+        if (enPassantInfo.getFirst()) {
+            ChessboardPos posTakenPawn = enPassantInfo.getSecond();
+            chessboard[posTakenPawn.row][posTakenPawn.col] = new Piece(
+                    new ChessboardPos(posTakenPawn),
+                    Piece.PieceColor.NONE,
+                    this
+            );
+        }
     }
 
     /**
      * Try to move a piece to dest given coordinate.
      * This method is entry point to move a piece, updating Chessboard.
-     *
-     * @param src A coordinate of a piece which wants to move
-     * @param dest A coordinate of a destination
-     */
-    public boolean tryMovePiece(ChessboardPos src, ChessboardPos dest) {
-        if (!src.isValid())
-            return false;
-        if (!dest.isValid())
-            return false;
-        if (getPiece(src).pieceColor != turnNow)
-            return false;
-        return getPiece(src).testAndMove(dest);
-    }
-
-    /**
-     * Try to move a piece to dest given coordinate.
-     * This method is entry point to move a piece, updating Chessboard.
+     * IF MOVE IS PROMOTION, NEED TO SET `move` WITH `ChessboardMove::move.setPromotionToWhat()`.
      *
      * @param move Coordinates of squares, start and destination.
      */
     public boolean tryMovePiece(ChessboardMove move) {
-        return getPiece(move.startPosition).testAndMove(move.endPosition);
+        if (!move.startPosition.isValid())
+            return false;
+        if (!move.endPosition.isValid())
+            return false;
+        if (getPiece(move.startPosition).pieceColor != turnNow)
+            return false;
+
+        var src = move.startPosition;
+        var dest = move.endPosition;
+
+        Piece srcPiece = getPiece(src);
+        Piece destPiece = getPiece(src);
+        var befo_nullable_lastMoved = nullable_lastMoved;
+        var kingMaybeChecked = turnNow == Piece.PieceColor.BLACK ?
+                blackKing : whiteKing;
+
+        boolean ret;
+        if (move.getPromotionInfo().getFirst()) {
+            switch (move.getPromotionInfo().getSecond()) {
+                case QUEEN :
+                case ROOK :
+                case BISHOP :
+                case KNIGHT :
+                    ret = ((Pawn)getPiece(move.startPosition)).testAndMovePromotion(move);
+                    break;
+                default:
+                    ret =  false;
+            }
+        } else
+            ret = getPiece(move.startPosition).testAndMove(move.endPosition);
+
+        /* Revert last move if check does been not resolved. */
+        if (ret && kingMaybeChecked.checked()) {
+            nullable_lastMoved = befo_nullable_lastMoved;
+            chessboard[src.row][src.col] = srcPiece;
+            chessboard[dest.row][dest.col] = destPiece;
+
+            if (turnNow == Piece.PieceColor.BLACK) {
+                turnNow = Piece.PieceColor.WHITE;
+            } else {
+                turnNow = Piece.PieceColor.BLACK;
+            }
+
+            moveRecords.removeLast();
+
+            if (move.isCastling()) {
+                ChessboardPos castleDirection = ChessboardPos.sub(dest, src);
+                int colOfRook;
+                if (castleDirection.col > 0) {
+                    colOfRook = 7;
+                } else {
+                    colOfRook = 0;
+                }
+
+                int rowOfRook = dest.row;
+
+                ChessboardPos newPosOfRook = new ChessboardPos(
+                        rowOfRook,
+                        castleDirection.col > 0 ? dest.col - 1 : dest.col + 1
+                );
+
+                chessboard[rowOfRook][colOfRook] = chessboard[newPosOfRook.row][newPosOfRook.col];
+                chessboard[rowOfRook][colOfRook].position = new ChessboardPos(rowOfRook, colOfRook);
+                chessboard[newPosOfRook.row][newPosOfRook.col] = new Piece(
+                        new ChessboardPos(rowOfRook, colOfRook),
+                        Piece.PieceColor.NONE,
+                        this
+                );
+            }
+
+            if (move.getEnPassantInfo().getFirst()) {
+                ChessboardPos pawnTaken = move.getEnPassantInfo().getSecond();
+                chessboard[pawnTaken.row][pawnTaken.col] = new Pawn(
+                        new ChessboardPos(pawnTaken),
+                        (turnNow == Piece.PieceColor.BLACK) ? Piece.PieceColor.WHITE : Piece.PieceColor.BLACK,
+                        this,
+                        (turnNow == Piece.PieceColor.BLACK) ? new ChessboardPos(1, 0) : new ChessboardPos(-1, 0)
+                );
+            }
+            return false;
+        }
+        return ret;
     }
 
     /**
@@ -119,7 +260,7 @@ public class Chessboard {
         chessboard[0][1] = new Knight(new ChessboardPos(0, 1), Piece.PieceColor.BLACK, this);
         chessboard[0][2] = new Bishop(new ChessboardPos(0, 2), Piece.PieceColor.BLACK, this);
         chessboard[0][3] = new Queen(new ChessboardPos(0, 3), Piece.PieceColor.BLACK, this);
-        chessboard[0][4] = new King(new ChessboardPos(0, 4), Piece.PieceColor.BLACK, this);
+        chessboard[0][4] = blackKing = new King(new ChessboardPos(0, 4), Piece.PieceColor.BLACK, this);
         chessboard[0][5] = new Bishop(new ChessboardPos(0, 5), Piece.PieceColor.BLACK, this);
         chessboard[0][6] = new Knight(new ChessboardPos(0, 6), Piece.PieceColor.BLACK, this);
         chessboard[0][7] = new Rook(new ChessboardPos(0, 7), Piece.PieceColor.BLACK, this);
@@ -132,7 +273,7 @@ public class Chessboard {
         chessboard[7][1] = new Knight(new ChessboardPos(7, 1), Piece.PieceColor.WHITE, this);
         chessboard[7][2] = new Bishop(new ChessboardPos(7, 2), Piece.PieceColor.WHITE, this);
         chessboard[7][3] = new Queen(new ChessboardPos(7, 3), Piece.PieceColor.WHITE, this);
-        chessboard[7][4] = new King(new ChessboardPos(7, 4), Piece.PieceColor.WHITE, this);
+        chessboard[7][4] = whiteKing = new King(new ChessboardPos(7, 4), Piece.PieceColor.WHITE, this);
         chessboard[7][5] = new Bishop(new ChessboardPos(7, 5), Piece.PieceColor.WHITE, this);
         chessboard[7][6] = new Knight(new ChessboardPos(7, 6), Piece.PieceColor.WHITE, this);
         chessboard[7][7] = new Rook(new ChessboardPos(7, 7), Piece.PieceColor.WHITE, this);
@@ -152,3 +293,63 @@ public class Chessboard {
         moveRecords = new LinkedList<>();
     }
 }
+
+//public boolean tryMoveAndRollback(ChessboardMove move) {
+//    var src = move.startPosition;
+//    var dest = move.endPosition;
+//
+//    Piece srcPiece = getPiece(src);
+//    Piece destPiece = getPiece(src);
+//    var befo_nullable_lastMoved = nullable_lastMoved;
+//
+//    var ret = tryMovePiece(src, dest);
+//    if (ret) {
+//        nullable_lastMoved = befo_nullable_lastMoved;
+//        chessboard[src.row][src.col] = srcPiece;
+//        chessboard[dest.row][dest.col] = destPiece;
+//
+//        if (turnNow == Piece.PieceColor.BLACK) {
+//            turnNow = Piece.PieceColor.WHITE;
+//        } else {
+//            turnNow = Piece.PieceColor.BLACK;
+//        }
+//
+//        moveRecords.removeLast();
+//
+//        if (move.isCastling()) {
+//            ChessboardPos castleDirection = ChessboardPos.sub(dest, src);
+//            int colOfRook;
+//            if (castleDirection.col > 0) {
+//                colOfRook = 7;
+//            } else {
+//                colOfRook = 0;
+//            }
+//
+//            int rowOfRook = dest.row;
+//
+//            ChessboardPos newPosOfRook = new ChessboardPos(
+//                    rowOfRook,
+//                    castleDirection.col > 0 ? dest.col - 1 : dest.col + 1
+//            );
+//
+//            chessboard[rowOfRook][colOfRook] = chessboard[newPosOfRook.row][newPosOfRook.col];
+//            chessboard[rowOfRook][colOfRook].position = new ChessboardPos(rowOfRook, colOfRook);
+//            chessboard[newPosOfRook.row][newPosOfRook.col] = new Piece(
+//                    new ChessboardPos(rowOfRook, colOfRook),
+//                    Piece.PieceColor.NONE,
+//                    this
+//            );
+//        }
+//
+//        if (move.getEnPassantInfo().getFirst()) {
+//            ChessboardPos pawnTaken = move.getEnPassantInfo().getSecond();
+//            chessboard[pawnTaken.row][pawnTaken.col] = new Pawn(
+//                    new ChessboardPos(pawnTaken),
+//                    (turnNow == Piece.PieceColor.BLACK) ? Piece.PieceColor.WHITE : Piece.PieceColor.BLACK,
+//                    this,
+//                    (turnNow == Piece.PieceColor.BLACK) ? new ChessboardPos(1, 0) : new ChessboardPos(-1, 0)
+//            );
+//        }
+//    }
+//    return ret;
+//}

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Chessboard.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Chessboard.java
@@ -11,7 +11,7 @@ import java.util.LinkedList;
  */
 public class Chessboard {
     /**
-     * chessboard of game. 8x8 grid of Pieces.
+     * Chessboard of game. 8x8 grid of Pieces.
      */
     private Piece[][] chessboard;
 
@@ -32,12 +32,12 @@ public class Chessboard {
     public LinkedList<ChessboardMove> moveRecords;
 
     /**
-     * get piece in the square, `chessboard[row][col]`.
+     * Get piece in the square, `chessboard[row][col]`.
      * Caller must check if coordinate is valid.
      *
-     * @param row row index of board.
-     * @param col cow index of board.
-     * @return piece in the square at given coordinate.
+     * @param row Row index of board.
+     * @param col Cow index of board.
+     * @return Piece in the square at given coordinate.
      */
     public Piece getPiece(int row, int col) {
         Assert.isTrue(ChessboardPos.isValid(row, col), "Chessboard::getPiece() invalid arguments");
@@ -45,7 +45,7 @@ public class Chessboard {
     }
 
     /**
-     * get piece at given coordinate, `pos`
+     * Get piece at given coordinate, `pos`
      * Caller must check if coordinate is valid.
      *
      * @param pos coordinate in chessboard
@@ -57,14 +57,13 @@ public class Chessboard {
     }
 
     /**
-     * move a piece to dest in given coordinate.
+     * Move a piece to dest in given coordinate.
      * It is a safe way to update chessboard, maintaining coherency between chessboard and pieces.
      *
-     * @param src a coordinate of a piece which wants to move
-     * @param dest a coordinate of a destination
-     * @return `this` Chessboard instance
+     * @param src A coordinate of a piece which wants to move
+     * @param dest A coordinate of a destination
      */
-    public Chessboard movePiece(ChessboardPos src, ChessboardPos dest) {
+    public void movePiece(ChessboardPos src, ChessboardPos dest) {
         chessboard[dest.row][dest.col] = chessboard[src.row][src.col];
         chessboard[src.row][src.col] = new Piece(new ChessboardPos(src), Piece.PieceColor.NONE, this);
 
@@ -80,11 +79,31 @@ public class Chessboard {
         } else {
             turn = Piece.PieceColor.BLACK;
         }
-        return this;
     }
 
     /**
-     * constructor to generate initial state of chessboard
+     * Try to move a piece to dest given coordinate.
+     * This method is entry point to move a piece, updating Chessboard.
+     *
+     * @param src A coordinate of a piece which wants to move
+     * @param dest A coordinate of a destination
+     */
+    public boolean tryMovePiece(ChessboardPos src, ChessboardPos dest) {
+        return getPiece(src).testAndMove(dest);
+    }
+
+    /**
+     * Try to move a piece to dest given coordinate.
+     * This method is entry point to move a piece, updating Chessboard.
+     *
+     * @param move Coordinates of squares, start and destination.
+     */
+    public boolean tryMovePiece(ChessboardMove move) {
+        return getPiece(move.startPosition).testAndMove(move.endPosition);
+    }
+
+    /**
+     * Constructor to generate initial state of chessboard
      */
     public Chessboard() {
         final int BOARD_SIZE = 8;

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Chessboard.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Chessboard.java
@@ -24,7 +24,7 @@ public class Chessboard {
     /**
      * Piece color which represents that which side has turn now.
      */
-    public Piece.PieceColor turn;
+    public Piece.PieceColor turnNow;
 
     /**
      * Records of moves. (History of moves)
@@ -74,10 +74,10 @@ public class Chessboard {
 
         moveRecords.add(new ChessboardMove(new ChessboardPos(src), new ChessboardPos(dest)));
 
-        if (turn == Piece.PieceColor.BLACK) {
-            turn = Piece.PieceColor.WHITE;
+        if (turnNow == Piece.PieceColor.BLACK) {
+            turnNow = Piece.PieceColor.WHITE;
         } else {
-            turn = Piece.PieceColor.BLACK;
+            turnNow = Piece.PieceColor.BLACK;
         }
     }
 
@@ -89,6 +89,12 @@ public class Chessboard {
      * @param dest A coordinate of a destination
      */
     public boolean tryMovePiece(ChessboardPos src, ChessboardPos dest) {
+        if (!src.isValid())
+            return false;
+        if (!dest.isValid())
+            return false;
+        if (getPiece(src).pieceColor != turnNow)
+            return false;
         return getPiece(src).testAndMove(dest);
     }
 
@@ -142,7 +148,7 @@ public class Chessboard {
         }
 
         nullable_lastMoved = null;
-        turn = Piece.PieceColor.WHITE;
+        turnNow = Piece.PieceColor.WHITE;
         moveRecords = new LinkedList<>();
     }
 }

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/ChessboardMove.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/ChessboardMove.java
@@ -4,19 +4,19 @@ import lombok.Getter;
 import lombok.Setter;
 
 /**
- * class to record moves
+ * Class to record moves
  * Must be set after checking is move valid, because this class doesn't care if it is valid.
  */
 @Getter
 @Setter
 public class ChessboardMove {
     /**
-     * moved piece's position before move
+     * Moved piece's position before move
      */
     public ChessboardPos startPosition;
 
     /**
-     * moved piece's position after move
+     * Moved piece's position after move
      */
     public ChessboardPos endPosition;
 

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/ChessboardMove.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/ChessboardMove.java
@@ -1,0 +1,27 @@
+package com.example.chessdotnet.service.chessGameSession;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * class to record moves
+ * Must be set after checking is move valid, because this class doesn't care if it is valid.
+ */
+@Getter
+@Setter
+public class ChessboardMove {
+    /**
+     * moved piece's position before move
+     */
+    public ChessboardPos startPosition;
+
+    /**
+     * moved piece's position after move
+     */
+    public ChessboardPos endPosition;
+
+    public ChessboardMove(ChessboardPos src, ChessboardPos dest) {
+        startPosition = src;
+        endPosition = dest;
+    }
+}

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/ChessboardMove.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/ChessboardMove.java
@@ -1,14 +1,11 @@
 package com.example.chessdotnet.service.chessGameSession;
 
-import lombok.Getter;
-import lombok.Setter;
+import org.springframework.data.util.Pair;
 
 /**
  * Class to record moves
  * Must be set after checking is move valid, because this class doesn't care if it is valid.
  */
-@Getter
-@Setter
 public class ChessboardMove {
     /**
      * Moved piece's position before move
@@ -20,8 +17,122 @@ public class ChessboardMove {
      */
     public ChessboardPos endPosition;
 
+    /**
+     * Type of the moved piece after promoted.
+     */
+    private Piece.PieceType promotionToWhat;
+
+    /**
+     * Coordinate of piece taken by the move, en passant(=this move).
+     */
+    private ChessboardPos posTakenByEnPassant;
+
+    /**
+     * True when this move is castling. (in any way)
+     */
+    private boolean isCastling;
+
+    /**
+     * If `promotionToWhat`, `posTakenByEnPassant`, or `isCastling` is set, this is `true`.
+     */
+    private boolean isSpecialMove;
+
+
+    /**
+     * Get Information of promotionToWhat. It can be null, if this move is not a promotion.
+     *
+     * @return First element of Pair represents is it not null, the second is actual information.
+     * If the first is `false`, the second is meaningless.
+     */
+    public Pair<Boolean, Piece.PieceType> getPromotionInfo() {
+        if (promotionToWhat == null) {
+            return Pair.of(false, Piece.PieceType.KING);
+        } else {
+            return Pair.of(true, promotionToWhat);
+        }
+    }
+
+    /**
+     * Get Information of posTakenByEnPassant. It can be null, if this move is not an en passant.
+     *
+     * @return First element of Pair represents is it not null, the second is actual information.
+     * If the first is `false`, the second is meaningless.
+     */
+    public Pair<Boolean, ChessboardPos> getEnPassantInfo() {
+        if (posTakenByEnPassant == null) {
+            return Pair.of(false, new ChessboardPos(-1, -1));
+        } else {
+            return Pair.of(true, posTakenByEnPassant);
+        }
+    }
+
+    /**
+     * Get if it is a castling.
+     *
+     * @return True if this move is castling.
+     */
+    public boolean isCastling() {
+        return isCastling;
+    }
+
+    /**
+     * Get if `promotionToWhat`, `posTakenByEnPassant`, or `isCastling` is set.
+     *
+     * @return True if one of them is set.
+     */
+    public boolean isSpecialMove() {
+        return isSpecialMove;
+    }
+
+    /**
+     * Set the promotion info.
+     *
+     * @param pieceType Type of the moved piece after promoted.
+     * @return Return itself
+     */
+    public ChessboardMove setPromotionToWhat(Piece.PieceType pieceType) {
+        promotionToWhat = pieceType;
+        isSpecialMove = true;
+        return this;
+    }
+
+    /**
+     * Set the en passant info, with `posTakenByEnPassant`.
+     *
+     * @param posTakenByEnPassant Coordinate of the pawn, which is taken by this en passant.
+     * @return Return itself
+     */
+    public ChessboardMove setEnPassant(ChessboardPos posTakenByEnPassant) {
+        this.posTakenByEnPassant = posTakenByEnPassant;
+        isSpecialMove = true;
+        return this;
+    }
+
+    /**
+     * Set isCastling to true.
+     * @return Return itself
+     */
+    public ChessboardMove setCastling() {
+        isCastling = true;
+        isSpecialMove = true;
+        return this;
+    }
+
+
+
+    /**
+     * Default constructor.
+     *
+     * @param src Coordinate of the moved piece before moving.
+     * @param dest Coordinate of the moved piece after moving.
+     */
     public ChessboardMove(ChessboardPos src, ChessboardPos dest) {
         startPosition = src;
         endPosition = dest;
+
+        promotionToWhat = null;
+        posTakenByEnPassant = null;
+        isCastling = false;
+        isSpecialMove = false;
     }
 }

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/ChessboardPos.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/ChessboardPos.java
@@ -1,0 +1,105 @@
+package com.example.chessdotnet.service.chessGameSession;
+
+
+/**
+ * class to represent coordinate of chessboard.
+ * Be careful, Instance of this always can have invalid value.
+ */
+public class ChessboardPos {
+    /**
+     * row index of board. (valid value in chessboard is between 0-7)
+     */
+    public int row;
+
+    /**
+     * cow index of board. (valid value in chessboard is between 0-7)
+     */
+    public int col;
+
+    /**
+     * check if this ChessboardPos instance is legal.
+     * @return true if this ChessboardPos has legal values, in boundary 0~7.
+     */
+    public boolean isValid() {
+        return (0 <= row && row <= 7 && 0 <= col && col <= 7);
+    }
+
+    /**
+     * check if given position is legal.
+     * @return true if given position has legal values, in boundary 0~7.
+     */
+    public static boolean isValid(int row, int col) {
+        return (0 <= row && row <= 7 && 0 <= col && col <= 7);
+    }
+
+
+    /**
+     * construct by clone another ChessboardPos instance.
+     * @param pos another ChessboardPos instance to clone
+     */
+    public ChessboardPos(ChessboardPos pos) {
+        row = pos.row;
+        col = pos.col;
+    }
+
+    /**
+     * default constructor
+     * @param row row index of board.
+     * @param col cow index of board.
+     */
+    public ChessboardPos(int row, int col) {
+        this.row = row;
+        this.col = col;
+    }
+
+    /**
+     * check if this has same values to `operand`.
+     * @param operand another ChessboardPos to compare
+     * @return true if row and col are same each other.
+     */
+    @Override
+    public boolean equals(Object operand) {
+        if (!(operand instanceof ChessboardPos pos))
+            return false;
+        return (this.row == pos.row && this.col == pos.col);
+    }
+
+    /**
+     * add values of `operand` onto `this`
+     * @param operand operand to add
+     * @return itself (`this`)
+     */
+    public ChessboardPos add(ChessboardPos operand) {
+        this.row += operand.row;
+        this.col += operand.col;
+        return this;
+    }
+
+    /**
+     * Return new ChessboardPos, having sum of values of them. Simply put, it returns value of `lhs + rhs`
+     * There is no side effect.
+     * @param lhs left hand side of operator
+     * @param rhs right hand side of operator
+     * @return new ChessboardPos, having sum of values of them.
+     */
+    public static ChessboardPos add(ChessboardPos lhs, ChessboardPos rhs) {
+        ChessboardPos ret = new ChessboardPos(lhs);
+        ret.row += rhs.row;
+        ret.col += rhs.col;
+        return ret;
+    }
+
+    /**
+     * Return new ChessboardPos, having difference of values of them. Simply put, it returns value of `lhs - rhs`
+     * There is no side effect.
+     * @param lhs left hand side of operator
+     * @param rhs right hand side of operator
+     * @return new ChessboardPos, having sum of values of them.
+     */
+    public static ChessboardPos sub(ChessboardPos lhs, ChessboardPos rhs) {
+        ChessboardPos ret = new ChessboardPos(lhs);
+        ret.row -= rhs.row;
+        ret.col -= rhs.col;
+        return ret;
+    }
+}

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/ChessboardPos.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/ChessboardPos.java
@@ -2,31 +2,31 @@ package com.example.chessdotnet.service.chessGameSession;
 
 
 /**
- * class to represent coordinate of chessboard.
+ * Class to represent coordinate of chessboard.
  * Be careful, Instance of this always can have invalid value.
  */
 public class ChessboardPos {
     /**
-     * row index of board. (valid value in chessboard is between 0-7)
+     * Row index of board. (valid value in chessboard is between 0-7)
      */
     public int row;
 
     /**
-     * cow index of board. (valid value in chessboard is between 0-7)
+     * Cow index of board. (valid value in chessboard is between 0-7)
      */
     public int col;
 
     /**
-     * check if this ChessboardPos instance is legal.
-     * @return true if this ChessboardPos has legal values, in boundary 0~7.
+     * Check if this ChessboardPos instance is legal.
+     * @return True if this ChessboardPos has legal values, in boundary 0~7.
      */
     public boolean isValid() {
         return (0 <= row && row <= 7 && 0 <= col && col <= 7);
     }
 
     /**
-     * check if given position is legal.
-     * @return true if given position has legal values, in boundary 0~7.
+     * Check if given position is legal.
+     * @return True if given position has legal values, in boundary 0~7.
      */
     public static boolean isValid(int row, int col) {
         return (0 <= row && row <= 7 && 0 <= col && col <= 7);
@@ -34,8 +34,8 @@ public class ChessboardPos {
 
 
     /**
-     * construct by clone another ChessboardPos instance.
-     * @param pos another ChessboardPos instance to clone
+     * Construct by clone another ChessboardPos instance.
+     * @param pos Another ChessboardPos instance to clone
      */
     public ChessboardPos(ChessboardPos pos) {
         row = pos.row;
@@ -43,9 +43,9 @@ public class ChessboardPos {
     }
 
     /**
-     * default constructor
-     * @param row row index of board.
-     * @param col cow index of board.
+     * Default constructor
+     * @param row Row index of board.
+     * @param col Cow index of board.
      */
     public ChessboardPos(int row, int col) {
         this.row = row;
@@ -53,9 +53,9 @@ public class ChessboardPos {
     }
 
     /**
-     * check if this has same values to `operand`.
-     * @param operand another ChessboardPos to compare
-     * @return true if row and col are same each other.
+     * Check if this has same values to `operand`.
+     * @param operand Another ChessboardPos to compare
+     * @return True if row and col are same each other.
      */
     @Override
     public boolean equals(Object operand) {
@@ -65,9 +65,9 @@ public class ChessboardPos {
     }
 
     /**
-     * add values of `operand` onto `this`
-     * @param operand operand to add
-     * @return itself (`this`)
+     * Add values of `operand` onto `this`
+     * @param operand Operand to add
+     * @return Itself (`this`)
      */
     public ChessboardPos add(ChessboardPos operand) {
         this.row += operand.row;
@@ -78,9 +78,9 @@ public class ChessboardPos {
     /**
      * Return new ChessboardPos, having sum of values of them. Simply put, it returns value of `lhs + rhs`
      * There is no side effect.
-     * @param lhs left hand side of operator
-     * @param rhs right hand side of operator
-     * @return new ChessboardPos, having sum of values of them.
+     * @param lhs Left hand side of operator
+     * @param rhs Right hand side of operator
+     * @return New ChessboardPos, having sum of values of them.
      */
     public static ChessboardPos add(ChessboardPos lhs, ChessboardPos rhs) {
         ChessboardPos ret = new ChessboardPos(lhs);
@@ -92,9 +92,9 @@ public class ChessboardPos {
     /**
      * Return new ChessboardPos, having difference of values of them. Simply put, it returns value of `lhs - rhs`
      * There is no side effect.
-     * @param lhs left hand side of operator
-     * @param rhs right hand side of operator
-     * @return new ChessboardPos, having sum of values of them.
+     * @param lhs Left hand side of operator
+     * @param rhs Right hand side of operator
+     * @return New ChessboardPos, having sum of values of them.
      */
     public static ChessboardPos sub(ChessboardPos lhs, ChessboardPos rhs) {
         ChessboardPos ret = new ChessboardPos(lhs);

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/King.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/King.java
@@ -4,20 +4,20 @@ import java.util.LinkedList;
 
 public class King extends Piece {
     /**
-     * default constructor
+     * Default constructor
      *
-     * @param position position in chessboard.
-     * @param pieceColor color (maybe WHITE or BLACK) of this.
-     * @param chessboard chessboard where this piece exists.
+     * @param position Position in chessboard.
+     * @param pieceColor Color (maybe WHITE or BLACK) of this.
+     * @param chessboard Chessboard where this piece exists.
      */
     public King(ChessboardPos position, Piece.PieceColor pieceColor, Chessboard chessboard) {
         super(position, pieceColor, chessboard);
     }
 
     /**
-     * return its name(typename of piece)
+     * Return its name(typename of piece)
      *
-     * @return typename of piece
+     * @return Typename of piece
      */
     @Override
     public String toString() {
@@ -25,10 +25,10 @@ public class King extends Piece {
     }
 
     /**
-     * check is it Empty Square (Not a Piece)
+     * Check is it Empty Square (Not a Piece)
      * Must be overridden
      *
-     * @return true if it is empty square
+     * @return True if it is empty square
      */
     @Override
     public boolean isEmptySquare() {
@@ -90,9 +90,9 @@ public class King extends Piece {
     }
 
     /**
-     * check if this king has threat. (determine is it `check`)
+     * Check if this king has threat. (determine is it `check`)
      *
-     * @return true if this king has threat.
+     * @return True if this king has threat.
      */
     public boolean checked() {
         return hasThreatAtSquare(this.position);
@@ -137,12 +137,12 @@ public class King extends Piece {
     }
 
     /**
-     * update its position and chessboard, if dest is reachable in one move by itself.
+     * Update its position and chessboard, if dest is reachable in one move by itself.
      * It is a safe way to update chessboard, maintaining coherency between `piece.position`
      * and actual position in chessboard.
      *
-     * @param dest destination of move to test
-     * @return true if and only if position updated.
+     * @param dest Destination of move to test
+     * @return true If and only if position updated.
      */
     @Override
     public boolean testAndMove(ChessboardPos dest) {

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/King.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/King.java
@@ -1,0 +1,157 @@
+package com.example.chessdotnet.service.chessGameSession;
+
+import java.util.LinkedList;
+
+public class King extends Piece {
+    /**
+     * default constructor
+     *
+     * @param position position in chessboard.
+     * @param pieceColor color (maybe WHITE or BLACK) of this.
+     * @param chessboard chessboard where this piece exists.
+     */
+    public King(ChessboardPos position, Piece.PieceColor pieceColor, Chessboard chessboard) {
+        super(position, pieceColor, chessboard);
+    }
+
+    /**
+     * return its name(typename of piece)
+     *
+     * @return typename of piece
+     */
+    @Override
+    public String toString() {
+        return "King";
+    }
+
+    /**
+     * check is it Empty Square (Not a Piece)
+     * Must be overridden
+     *
+     * @return true if it is empty square
+     */
+    @Override
+    public boolean isEmptySquare() {
+        return false;
+    }
+
+    public boolean hasThreatAtSquare(ChessboardPos pos) {
+
+        ChessboardPos[] directions = {
+                new ChessboardPos(1, 1),
+                new ChessboardPos(1, -1),
+                new ChessboardPos(-1, 1),
+                new ChessboardPos(-1, -1),
+                new ChessboardPos(1, 0),
+                new ChessboardPos(-1, 0),
+                new ChessboardPos(0, 1),
+                new ChessboardPos(0, -1)
+        };
+
+        for (var direction : directions) {
+            LinkedList<ChessboardPos> squaresToCheck = new LinkedList<>();
+            addSquaresInDirection(squaresToCheck, direction);
+            if (squaresToCheck.isEmpty())
+                continue;
+            var piece = chessboard.getPiece(squaresToCheck.getLast());
+            if (piece.isEmptySquare())
+                continue;
+            if (piece.toString().equals(PieceType.KING.name) && squaresToCheck.size() == 1) {
+                return true;
+            }
+            if (piece.getDestinations().contains(pos))
+                return true;
+        }
+
+        //noinspection DuplicatedCode
+        ChessboardPos[] knightMoves = {
+                new ChessboardPos(pos.row + 2, pos.col + 1),
+                new ChessboardPos(pos.row + 2, pos.col - 1),
+                new ChessboardPos(pos.row - 2, pos.col+ 1),
+                new ChessboardPos(pos.row - 2, pos.col - 1),
+                new ChessboardPos(pos.row + 1, pos.col + 2),
+                new ChessboardPos(pos.row+ 1, pos.col - 2),
+                new ChessboardPos(pos.row - 1, pos.col + 2),
+                new ChessboardPos(pos.row - 1, pos.col - 2)
+        };
+
+        for (var candidate : knightMoves) {
+            if (!candidate.isValid())
+                continue;
+
+            if (!chessboard.getPiece(candidate).isEmptySquare()
+                    && chessboard.getPiece(candidate).pieceColor != this.pieceColor
+                    && chessboard.getPiece(candidate).toString().equals(PieceType.KNIGHT.name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * check if this king has threat. (determine is it `check`)
+     *
+     * @return true if this king has threat.
+     */
+    public boolean checked() {
+        return hasThreatAtSquare(this.position);
+    }
+
+    /**
+     * Get its possible destinations of its legal moves.
+     *
+     * @return LinkedList of ChessboardPos which contains possible destinations of its legal moves.
+     */
+    @Override
+    public LinkedList<ChessboardPos> getDestinations() {
+        LinkedList<ChessboardPos> dests = new LinkedList<>();
+
+        ChessboardPos[] candidates = {
+                new ChessboardPos(position.row + 1, position.col + 1),
+                new ChessboardPos(position.row + 1, position.col - 1),
+                new ChessboardPos(position.row - 1, position.col + 1),
+                new ChessboardPos(position.row - 1, position.col - 1),
+                new ChessboardPos(position.row + 1, position.col),
+                new ChessboardPos(position.row - 1, position.col),
+                new ChessboardPos(position.row, position.col + 1),
+                new ChessboardPos(position.row, position.col - 1)
+        };
+
+        for (var candidatePos : candidates) {
+            if (!candidatePos.isValid())
+                continue;
+
+            if (hasThreatAtSquare(candidatePos))
+                continue;
+
+            /* check it is empty or can be taken (only check if its color is different to this) */
+            if (chessboard.getPiece(candidatePos).isEmptySquare()) {
+                dests.add(new ChessboardPos(candidatePos));
+            } else if (chessboard.getPiece(candidatePos).pieceColor != this.pieceColor) {
+                dests.add(new ChessboardPos(candidatePos));
+            }
+        }
+
+        return dests;
+    }
+
+    /**
+     * update its position and chessboard, if dest is reachable in one move by itself.
+     * It is a safe way to update chessboard, maintaining coherency between `piece.position`
+     * and actual position in chessboard.
+     *
+     * @param dest destination of move to test
+     * @return true if and only if position updated.
+     */
+    @Override
+    public boolean testAndMove(ChessboardPos dest) {
+        LinkedList<ChessboardPos> possibleDests = getDestinations();
+        if (possibleDests.contains(dest)) {
+            chessboard.movePiece(this.position, dest);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Knight.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Knight.java
@@ -1,0 +1,91 @@
+package com.example.chessdotnet.service.chessGameSession;
+
+import java.util.LinkedList;
+
+public class Knight extends Piece {
+    /**
+     * default constructor
+     *
+     * @param position position in chessboard.
+     * @param pieceColor color (maybe WHITE or BLACK) of this.
+     * @param chessboard chessboard where this piece exists.
+     */
+    public Knight(ChessboardPos position, Piece.PieceColor pieceColor, Chessboard chessboard) {
+        super(position, pieceColor, chessboard);
+    }
+
+    /**
+     * return its name(typename of piece)
+     *
+     * @return typename of piece
+     */
+    @Override
+    public String toString() {
+        return "Knight";
+    }
+
+    /**
+     * check is it Empty Square (Not a Piece)
+     * Must be overridden
+     *
+     * @return true if it is empty square
+     */
+    @Override
+    public boolean isEmptySquare() {
+        return false;
+    }
+
+    /**
+     * Get its possible destinations of its legal moves.
+     *
+     * @return LinkedList of ChessboardPos which contains possible destinations of its legal moves.
+     */
+    @Override
+    public LinkedList<ChessboardPos> getDestinations() {
+        LinkedList<ChessboardPos> dests = new LinkedList<>();
+
+        //noinspection DuplicatedCode
+        ChessboardPos[] candidates = {
+                new ChessboardPos(position.row + 2, position.col + 1),
+                new ChessboardPos(position.row + 2, position.col - 1),
+                new ChessboardPos(position.row - 2, position.col + 1),
+                new ChessboardPos(position.row - 2, position.col - 1),
+                new ChessboardPos(position.row + 1, position.col + 2),
+                new ChessboardPos(position.row + 1, position.col - 2),
+                new ChessboardPos(position.row - 1, position.col + 2),
+                new ChessboardPos(position.row - 1, position.col - 2)
+        };
+
+        for (var candidatePos : candidates) {
+            if (!candidatePos.isValid())
+                continue;
+            /* check it is empty or can be taken (only check if its color is different to this) */
+            if (chessboard.getPiece(candidatePos).isEmptySquare()) {
+                dests.add(new ChessboardPos(candidatePos));
+            } else if (chessboard.getPiece(candidatePos).pieceColor != this.pieceColor) {
+                dests.add(new ChessboardPos(candidatePos));
+            }
+        }
+
+        return dests;
+    }
+
+    /**
+     * update its position and chessboard, if dest is reachable in one move by itself.
+     * It is a safe way to update chessboard, maintaining coherency between `piece.position`
+     * and actual position in chessboard.
+     *
+     * @param dest destination of move to test
+     * @return true if and only if position updated.
+     */
+    @Override
+    public boolean testAndMove(ChessboardPos dest) {
+        LinkedList<ChessboardPos> possibleDests = getDestinations();
+        if (possibleDests.contains(dest)) {
+            chessboard.movePiece(this.position, dest);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Knight.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Knight.java
@@ -82,7 +82,10 @@ public class Knight extends Piece {
     public boolean testAndMove(ChessboardPos dest) {
         LinkedList<ChessboardPos> possibleDests = getDestinations();
         if (possibleDests.contains(dest)) {
-            chessboard.movePiece(this.position, dest);
+            chessboard.movePiece(new ChessboardMove(
+                    new ChessboardPos(this.position),
+                    new ChessboardPos(dest)
+            ));
             return true;
         }
 

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Knight.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Knight.java
@@ -4,20 +4,20 @@ import java.util.LinkedList;
 
 public class Knight extends Piece {
     /**
-     * default constructor
+     * Default constructor
      *
-     * @param position position in chessboard.
-     * @param pieceColor color (maybe WHITE or BLACK) of this.
-     * @param chessboard chessboard where this piece exists.
+     * @param position Position in chessboard.
+     * @param pieceColor Color (maybe WHITE or BLACK) of this.
+     * @param chessboard Chessboard where this piece exists.
      */
     public Knight(ChessboardPos position, Piece.PieceColor pieceColor, Chessboard chessboard) {
         super(position, pieceColor, chessboard);
     }
 
     /**
-     * return its name(typename of piece)
+     * Return its name(typename of piece)
      *
-     * @return typename of piece
+     * @return Typename of piece
      */
     @Override
     public String toString() {
@@ -25,10 +25,10 @@ public class Knight extends Piece {
     }
 
     /**
-     * check is it Empty Square (Not a Piece)
+     * Check is it Empty Square (Not a Piece)
      * Must be overridden
      *
-     * @return true if it is empty square
+     * @return True if it is empty square
      */
     @Override
     public boolean isEmptySquare() {
@@ -71,12 +71,12 @@ public class Knight extends Piece {
     }
 
     /**
-     * update its position and chessboard, if dest is reachable in one move by itself.
+     * Update its position and chessboard, if dest is reachable in one move by itself.
      * It is a safe way to update chessboard, maintaining coherency between `piece.position`
      * and actual position in chessboard.
      *
-     * @param dest destination of move to test
-     * @return true if and only if position updated.
+     * @param dest Destination of move to test
+     * @return True if and only if position updated.
      */
     @Override
     public boolean testAndMove(ChessboardPos dest) {

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Pawn.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Pawn.java
@@ -1,0 +1,128 @@
+package com.example.chessdotnet.service.chessGameSession;
+
+import java.util.LinkedList;
+
+
+/**
+ * Pawn class of chess piece
+ */
+public class Pawn extends Piece {
+    /**
+     * direction of forward of this pawn. (At now, this class supports only case that `directionForward.col` is zero.)
+     */
+    public ChessboardPos directionForward;
+
+    /**
+     * default constructor
+     *
+     * @param position position in chessboard.
+     * @param pieceColor color (maybe WHITE or BLACK) of this.
+     * @param chessboard chessboard where this piece exists.
+     * @param directionForward stride of this pawn in forward.
+     */
+    public Pawn(ChessboardPos position, PieceColor pieceColor, Chessboard chessboard, ChessboardPos directionForward) {
+        super(position, pieceColor, chessboard);
+        this.directionForward = directionForward;
+    }
+
+    /**
+     * return its name(typename of piece)
+     *
+     * @return typename of piece
+     */
+    @Override
+    public String toString() {
+        return "Pawn";
+    }
+
+    /**
+     * check is it Empty Square (Not a Piece)
+     * Must be overridden
+     *
+     * @return true if it is empty square
+     */
+    @Override
+    public boolean isEmptySquare() {
+        return false;
+    }
+
+    /**
+     * Get its possible destinations of its legal moves.
+     * Implementing this logic was ........................................................
+     *
+     * @return LinkedList of ChessboardPos which contains possible destinations of its legal moves.
+     */
+    @Override
+    public LinkedList<ChessboardPos> getDestinations() {
+        LinkedList<ChessboardPos> dests = new LinkedList<>();
+
+        ChessboardPos leftDiagonal = new ChessboardPos(position.row + directionForward.row, position.col - 1);
+        ChessboardPos rightDiagonal = new ChessboardPos(position.row + directionForward.row, position.col + 1);
+        ChessboardPos forward = new ChessboardPos(position.row + directionForward.row, position.col);
+
+        ChessboardPos[] diagonals = { leftDiagonal, rightDiagonal };
+        for (var diagonal : diagonals) {
+            if (diagonal.isValid()
+                    && !chessboard.getPiece(diagonal).isEmptySquare()
+                    && chessboard.getPiece(diagonal).pieceColor != this.pieceColor) {
+                dests.add(new ChessboardPos(diagonal));
+                continue;
+            }
+
+            /* step to check en passant */
+            int direction = diagonal.col - position.col;
+            if (!ChessboardPos.isValid(position.row, position.col + direction))
+                continue;
+
+            if (!chessboard
+                    .getPiece(position.row, position.col + direction)
+                    .toString()
+                    .equals("Pawn"))
+                continue;
+
+            if (chessboard.moveRecords.isEmpty())
+                continue;
+
+            if (chessboard.nullable_lastMoved != chessboard.getPiece(position.row, position.col + direction))
+                continue;
+
+            var lastMove = chessboard.moveRecords.getLast();
+            var strideLastMove = ChessboardPos.sub(lastMove.endPosition, lastMove.startPosition);
+
+            if (!((Math.abs(strideLastMove.row) == 2 && strideLastMove.col == 0)
+                    || (strideLastMove.row == 0 && Math.abs(strideLastMove.col) == 2)))
+                continue;
+
+            dests.add(new ChessboardPos(diagonal));
+        }
+
+        if (forward.isValid() && chessboard.getPiece(forward).isEmptySquare()) {
+            dests.add(new ChessboardPos(forward));
+            forward.add(directionForward);
+            /* check if pawn is able to move two steps */
+            if (!hasMoved && forward.isValid() && chessboard.getPiece(forward).isEmptySquare())
+                dests.add(new ChessboardPos(forward));
+        }
+
+        return dests;
+    }
+
+    /**
+     * update its position and chessboard, if dest is reachable in one move by itself.
+     * It is a safe way to update chessboard, maintaining coherency between `piece.position`
+     * and actual position in chessboard.
+     *
+     * @param dest destination of move to test
+     * @return true if and only if position updated.
+     */
+    @Override
+    public boolean testAndMove(ChessboardPos dest) {
+        LinkedList<ChessboardPos> possibleDests = getDestinations();
+        if (possibleDests.contains(dest)) {
+            chessboard.movePiece(this.position, dest);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Pawn.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Pawn.java
@@ -8,17 +8,17 @@ import java.util.LinkedList;
  */
 public class Pawn extends Piece {
     /**
-     * direction of forward of this pawn. (At now, this class supports only case that `directionForward.col` is zero.)
+     * Direction of forward of this pawn. (At now, this class supports only case that `directionForward.col` is zero.)
      */
     public ChessboardPos directionForward;
 
     /**
-     * default constructor
+     * Default constructor
      *
-     * @param position position in chessboard.
-     * @param pieceColor color (maybe WHITE or BLACK) of this.
-     * @param chessboard chessboard where this piece exists.
-     * @param directionForward stride of this pawn in forward.
+     * @param position Position in chessboard.
+     * @param pieceColor Color (maybe WHITE or BLACK) of this.
+     * @param chessboard Chessboard where this piece exists.
+     * @param directionForward Stride of this pawn in forward.
      */
     public Pawn(ChessboardPos position, PieceColor pieceColor, Chessboard chessboard, ChessboardPos directionForward) {
         super(position, pieceColor, chessboard);
@@ -26,9 +26,9 @@ public class Pawn extends Piece {
     }
 
     /**
-     * return its name(typename of piece)
+     * Return its name(typename of piece)
      *
-     * @return typename of piece
+     * @return Typename of piece
      */
     @Override
     public String toString() {
@@ -36,10 +36,10 @@ public class Pawn extends Piece {
     }
 
     /**
-     * check is it Empty Square (Not a Piece)
+     * Check is it Empty Square (Not a Piece)
      * Must be overridden
      *
-     * @return true if it is empty square
+     * @return True if it is empty square
      */
     @Override
     public boolean isEmptySquare() {
@@ -108,12 +108,12 @@ public class Pawn extends Piece {
     }
 
     /**
-     * update its position and chessboard, if dest is reachable in one move by itself.
+     * Update its position and chessboard, if dest is reachable in one move by itself.
      * It is a safe way to update chessboard, maintaining coherency between `piece.position`
      * and actual position in chessboard.
      *
-     * @param dest destination of move to test
-     * @return true if and only if position updated.
+     * @param dest Destination of move to test
+     * @return True if and only if position updated.
      */
     @Override
     public boolean testAndMove(ChessboardPos dest) {

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Piece.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Piece.java
@@ -80,7 +80,6 @@ class Piece {
         this.chessboard = chessboard;
     }
 
-
     /**
      * Return its name(typename of piece)
      *
@@ -170,6 +169,7 @@ class Piece {
                 out.add(new ChessboardPos(candidatePos));
             } else if (chessboard.getPiece(candidatePos).pieceColor != this.pieceColor) {
                 out.add(new ChessboardPos(candidatePos));
+                return;
             } else {
                 /* from this position, blocked by the same colors */
                 break;

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Piece.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Piece.java
@@ -4,7 +4,7 @@ import java.util.LinkedList;
 
 
 /**
- * class, extended by Actual Pieces (Rook, Bishop, ..., etc.)
+ * Class, extended by Actual Pieces (Rook, Bishop, ..., etc.)
  * Itself, it means empty square in chessboard. (I know that's such an Anti-pattern)
  */
 class Piece {
@@ -47,31 +47,31 @@ class Piece {
     }
 
     /**
-     * position in chessboard of this
+     * Position in chessboard of this
      */
     public ChessboardPos position;
 
     /**
-     * color (maybe WHITE or BLACK) of this
+     * Color (maybe WHITE or BLACK) of this
      */
     public PieceColor pieceColor;
 
     /**
-     * true if it moves at least once.
+     * True if it moves at least once.
      */
     public boolean hasMoved;
 
     /**
-     * chessboard which this piece belongs to.
+     * Chessboard which this piece belongs to.
      */
     public Chessboard chessboard;
 
     /**
-     * default constructor
+     * Default constructor
      *
-     * @param position position in chessboard.
-     * @param pieceColor color (maybe WHITE or BLACK) of this.
-     * @param chessboard chessboard where this piece exists.
+     * @param position Position in chessboard.
+     * @param pieceColor Color (maybe WHITE or BLACK) of this.
+     * @param chessboard Chessboard where this piece exists.
      */
     public Piece(ChessboardPos position, PieceColor pieceColor, Chessboard chessboard) {
         this.position = position;
@@ -82,19 +82,19 @@ class Piece {
 
 
     /**
-     * return its name(typename of piece)
+     * Return its name(typename of piece)
      *
-     * @return typename of piece
+     * @return Typename of piece
      */
     public String toString() {
         return "Piece";
     }
 
     /**
-     * check is it Empty Square (Not a Piece)
+     * Check is it Empty Square (Not a Piece)
      * Must be overridden
      *
-     * @return true if it is empty square
+     * @return True if it is empty square
      */
     public boolean isEmptySquare() {
         return true;
@@ -110,10 +110,10 @@ class Piece {
     }
 
     /**
-     * update its position and chessboard, if dest is reachable in one move by itself.
+     * Update its position and chessboard, if dest is reachable in one move by itself.
      *
-     * @param dest destination of move to test
-     * @return true if and only if position updated.
+     * @param dest Destination of move to test
+     * @return True if and only if position updated.
      */
     public boolean testAndMove(ChessboardPos dest) {
         return false;
@@ -125,9 +125,9 @@ class Piece {
      * Don't be confused, it **does not** add values onto `this.position` in directly.
      * Note that, this method is not designed for pieces which can jump over another piece.
      *
-     * @param pos position of chessboard to check
-     * @param stride direction added on `this.position` repeatedly.
-     * @return true if given position can be obtained by adding stride on `this.position` repeatedly.
+     * @param pos Position of chessboard to check
+     * @param stride Direction added on `this.position` repeatedly.
+     * @return True if given position can be obtained by adding stride on `this.position` repeatedly.
      */
     public boolean checkPosInDirection(ChessboardPos pos, ChessboardPos stride) {
         ChessboardPos candidatePos = new ChessboardPos(position);
@@ -155,8 +155,8 @@ class Piece {
      * Don't be confused, it **does not** add values onto `this.position` in directly.
      * Note that, this method is not designed for pieces which can jump over another piece.
      *
-     * @param out container to collect possible
-     * @param stride direction added on `this.position` repeatedly.
+     * @param out Container to collect possible
+     * @param stride Direction added on `this.position` repeatedly.
      */
     public void addSquaresInDirection(LinkedList<ChessboardPos> out, ChessboardPos stride) {
         ChessboardPos candidatePos = new ChessboardPos(position);

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Piece.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Piece.java
@@ -1,0 +1,179 @@
+package com.example.chessdotnet.service.chessGameSession;
+
+import java.util.LinkedList;
+
+
+/**
+ * class, extended by Actual Pieces (Rook, Bishop, ..., etc.)
+ * Itself, it means empty square in chessboard. (I know that's such an Anti-pattern)
+ */
+class Piece {
+    /**
+     * Manage same values for pieces' color (White or Black)
+     */
+    public enum PieceColor {
+        WHITE (0, "white"),
+        BLACK (1, "black"),
+        NONE (2, "none");
+
+        final public int idx;
+        final public String name;
+
+        PieceColor(int idx, String name) {
+            this.idx = idx;
+            this.name = name;
+        }
+    }
+
+    /**
+     * Manage same names for pieces' type
+     */
+    public enum PieceType {
+        KING ("King", "K"),
+        QUEEN ("Queen", "Q"),
+        ROOK ("Rook", "R"),
+        BISHOP ("Bishop", "B"),
+        KNIGHT ("Knight", "N"),
+        PAWN ("Pawn", "P");
+
+
+        final public String name;
+        final public String initial;
+
+        PieceType(String name, String initial) {
+            this.initial = initial;
+            this.name = name;
+        }
+    }
+
+    /**
+     * position in chessboard of this
+     */
+    public ChessboardPos position;
+
+    /**
+     * color (maybe WHITE or BLACK) of this
+     */
+    public PieceColor pieceColor;
+
+    /**
+     * true if it moves at least once.
+     */
+    public boolean hasMoved;
+
+    /**
+     * chessboard which this piece belongs to.
+     */
+    public Chessboard chessboard;
+
+    /**
+     * default constructor
+     *
+     * @param position position in chessboard.
+     * @param pieceColor color (maybe WHITE or BLACK) of this.
+     * @param chessboard chessboard where this piece exists.
+     */
+    public Piece(ChessboardPos position, PieceColor pieceColor, Chessboard chessboard) {
+        this.position = position;
+        this.pieceColor = pieceColor;
+        this.hasMoved = false;
+        this.chessboard = chessboard;
+    }
+
+
+    /**
+     * return its name(typename of piece)
+     *
+     * @return typename of piece
+     */
+    public String toString() {
+        return "Piece";
+    }
+
+    /**
+     * check is it Empty Square (Not a Piece)
+     * Must be overridden
+     *
+     * @return true if it is empty square
+     */
+    public boolean isEmptySquare() {
+        return true;
+    }
+
+    /**
+     * Get its possible destinations of its legal moves.
+     *
+     * @return LinkedList of ChessboardPos which contains possible destinations of its legal moves.
+     */
+    public LinkedList<ChessboardPos> getDestinations() {
+        return new LinkedList<>();
+    }
+
+    /**
+     * update its position and chessboard, if dest is reachable in one move by itself.
+     *
+     * @param dest destination of move to test
+     * @return true if and only if position updated.
+     */
+    public boolean testAndMove(ChessboardPos dest) {
+        return false;
+    }
+
+    /**
+     * Check given position can be obtained by adding stride on `this.position` repeatedly while
+     * position is valid. "valid" means not blocked by same colors and also valid position.
+     * Don't be confused, it **does not** add values onto `this.position` in directly.
+     * Note that, this method is not designed for pieces which can jump over another piece.
+     *
+     * @param pos position of chessboard to check
+     * @param stride direction added on `this.position` repeatedly.
+     * @return true if given position can be obtained by adding stride on `this.position` repeatedly.
+     */
+    public boolean checkPosInDirection(ChessboardPos pos, ChessboardPos stride) {
+        ChessboardPos candidatePos = new ChessboardPos(position);
+
+        while (candidatePos
+                .add(stride)
+                .isValid()) {
+
+            /* check it is empty or can be taken (only check if its color is different to this) */
+            if (chessboard.getPiece(candidatePos).isEmptySquare()) {
+                if (candidatePos.equals(pos)) return true;
+            } else if (chessboard.getPiece(candidatePos).pieceColor != this.pieceColor) {
+                if (candidatePos.equals(pos)) return true;
+            } else {
+                /* from this position, blocked by the same colors */
+                break;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Insert ChessboardPoses into out, which can be obtained by adding stride on `this.position` repeatedly while
+     * position is valid. "valid" means not blocked by same colors and also valid position.
+     * Don't be confused, it **does not** add values onto `this.position` in directly.
+     * Note that, this method is not designed for pieces which can jump over another piece.
+     *
+     * @param out container to collect possible
+     * @param stride direction added on `this.position` repeatedly.
+     */
+    public void addSquaresInDirection(LinkedList<ChessboardPos> out, ChessboardPos stride) {
+        ChessboardPos candidatePos = new ChessboardPos(position);
+
+        while (candidatePos
+                .add(stride)
+                .isValid()) {
+
+            /* check it is empty or can be taken (only check if its color is different to this) */
+            if (chessboard.getPiece(candidatePos).isEmptySquare()) {
+                out.add(new ChessboardPos(candidatePos));
+            } else if (chessboard.getPiece(candidatePos).pieceColor != this.pieceColor) {
+                out.add(new ChessboardPos(candidatePos));
+            } else {
+                /* from this position, blocked by the same colors */
+                break;
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Queen.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Queen.java
@@ -72,16 +72,19 @@ public class Queen extends Piece {
     @Override
     public boolean testAndMove(ChessboardPos dest) {
         //noinspection DuplicatedCode
-        ChessboardPos diff = ChessboardPos.sub(this.position, dest);
+        ChessboardPos diff = ChessboardPos.sub(dest, position);
 
         /* `diff.row == 0` is needed to check dest equals to this.position */
-        if (Math.abs(diff.row) == Math.abs(diff.col) || diff.row == 0) {
+        if (Math.abs(diff.row) == Math.abs(diff.col) && diff.row != 0) {
             /* make them into 1 or -1 */
             diff.row = diff.row / Math.abs(diff.row);
             diff.col = diff.col / Math.abs(diff.col);
 
             if (checkPosInDirection(dest, diff)) {
-                chessboard.movePiece(this.position, dest);
+                chessboard.movePiece(new ChessboardMove(
+                        new ChessboardPos(this.position),
+                        new ChessboardPos(dest)
+                ));
                 return true;
             }
             /* check if them have same row or col, but not both (XNOR) */
@@ -92,7 +95,10 @@ public class Queen extends Piece {
             if (diff.col != 0) diff.col /= Math.abs(diff.col);
 
             if (checkPosInDirection(dest, diff)) {
-                chessboard.movePiece(this.position, dest);
+                chessboard.movePiece(new ChessboardMove(
+                        new ChessboardPos(this.position),
+                        new ChessboardPos(dest)
+                ));
                 return true;
             }
         }

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Queen.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Queen.java
@@ -8,20 +8,20 @@ import java.util.LinkedList;
  */
 public class Queen extends Piece {
     /**
-     * default constructor
+     * Default constructor
      *
-     * @param position position in chessboard.
-     * @param pieceColor color (maybe WHITE or BLACK) of this.
-     * @param chessboard chessboard where this piece exists.
+     * @param position Position in chessboard.
+     * @param pieceColor Color (maybe WHITE or BLACK) of this.
+     * @param chessboard Chessboard where this piece exists.
      */
     public Queen(ChessboardPos position, PieceColor pieceColor, Chessboard chessboard) {
         super(position, pieceColor, chessboard);
     }
 
     /**
-     * return its name(typename of piece)
+     * Return its name(typename of piece)
      *
-     * @return typename of piece
+     * @return Typename of piece
      */
     @Override
     public String toString() {
@@ -29,10 +29,10 @@ public class Queen extends Piece {
     }
 
     /**
-     * check is it Empty Square (Not a Piece)
+     * Check is it Empty Square (Not a Piece)
      * Must be overridden
      *
-     * @return true if it is empty square
+     * @return True if it is empty square
      */
     @Override
     public boolean isEmptySquare() {
@@ -62,12 +62,12 @@ public class Queen extends Piece {
     }
 
     /**
-     * update its position and chessboard, if dest is reachable in one move by itself.
+     * Update its position and chessboard, if dest is reachable in one move by itself.
      * It is a safe way to update chessboard, maintaining coherency between `piece.position`
      * and actual position in chessboard.
      *
-     * @param dest destination of move to test
-     * @return true if and only if position updated.
+     * @param dest Destination of move to test
+     * @return True if and only if position updated.
      */
     @Override
     public boolean testAndMove(ChessboardPos dest) {

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Queen.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Queen.java
@@ -1,0 +1,101 @@
+package com.example.chessdotnet.service.chessGameSession;
+
+import java.util.LinkedList;
+
+
+/**
+ * Bishop class of chess piece
+ */
+public class Queen extends Piece {
+    /**
+     * default constructor
+     *
+     * @param position position in chessboard.
+     * @param pieceColor color (maybe WHITE or BLACK) of this.
+     * @param chessboard chessboard where this piece exists.
+     */
+    public Queen(ChessboardPos position, PieceColor pieceColor, Chessboard chessboard) {
+        super(position, pieceColor, chessboard);
+    }
+
+    /**
+     * return its name(typename of piece)
+     *
+     * @return typename of piece
+     */
+    @Override
+    public String toString() {
+        return "Queen";
+    }
+
+    /**
+     * check is it Empty Square (Not a Piece)
+     * Must be overridden
+     *
+     * @return true if it is empty square
+     */
+    @Override
+    public boolean isEmptySquare() {
+        return false;
+    }
+
+    /**
+     * Get its possible destinations of its legal moves.
+     *
+     * @return LinkedList of ChessboardPos which contains possible destinations of its legal moves.
+     */
+    @Override
+    public LinkedList<ChessboardPos> getDestinations() {
+        LinkedList<ChessboardPos> dests = new LinkedList<>();
+
+        addSquaresInDirection(dests, new ChessboardPos(1, 1));
+        addSquaresInDirection(dests, new ChessboardPos(1, -1));
+        addSquaresInDirection(dests, new ChessboardPos(-1, 1));
+        addSquaresInDirection(dests, new ChessboardPos(-1, -1));
+
+        addSquaresInDirection(dests, new ChessboardPos(0, 1));
+        addSquaresInDirection(dests, new ChessboardPos(0, -1));
+        addSquaresInDirection(dests, new ChessboardPos(-1, 0));
+        addSquaresInDirection(dests, new ChessboardPos(-1, 0));
+
+        return dests;
+    }
+
+    /**
+     * update its position and chessboard, if dest is reachable in one move by itself.
+     * It is a safe way to update chessboard, maintaining coherency between `piece.position`
+     * and actual position in chessboard.
+     *
+     * @param dest destination of move to test
+     * @return true if and only if position updated.
+     */
+    @Override
+    public boolean testAndMove(ChessboardPos dest) {
+        //noinspection DuplicatedCode
+        ChessboardPos diff = ChessboardPos.sub(this.position, dest);
+
+        /* `diff.row == 0` is needed to check dest equals to this.position */
+        if (Math.abs(diff.row) == Math.abs(diff.col) || diff.row == 0) {
+            /* make them into 1 or -1 */
+            diff.row = diff.row / Math.abs(diff.row);
+            diff.col = diff.col / Math.abs(diff.col);
+
+            if (checkPosInDirection(dest, diff)) {
+                chessboard.movePiece(this.position, dest);
+                return true;
+            }
+            /* check if them have same row or col, but not both (XNOR) */
+        } else if ((dest.row == position.row) != (dest.col == position.col)) {
+
+            /* get direction, src to dest */
+            if (diff.row != 0) diff.row /= Math.abs(diff.row);
+            if (diff.col != 0) diff.col /= Math.abs(diff.col);
+
+            if (checkPosInDirection(dest, diff)) {
+                chessboard.movePiece(this.position, dest);
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/README.md
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/README.md
@@ -1,0 +1,64 @@
+Author: SONY-STRING   
+
+Date: on first commit of this directory
+
+# About `class Chessboard`
+   
+Chessboard has hierarchy like below.
+
+   
+`class Chessboard`   
+-> `class Piece` (including derived classes)
+ 
+> There are some states which are need to be changed when a move performed.   
+   
+That states are distributed among `class Chessboard` and `class Piece`.   
+But, only `class Chessboard` is charge to manage them. You don't need worry that at **Pieces**.   
+   
+> Validate of a move
+
+There are two types of things to check.
+1. Valid Input
+2. Legality of the move
+
+"Valid move" in `Valid Input` is a move 
+which is from request of client in normal way.   
+In example, let a piece at `startPosition` of move as `P`.   
+If `P` has different color compare to the player color of this turn,
+That move is `invalid`. This is because client is **never** able to send this move
+request as client's program restricts for user to send illegal move.   
+At same time, I define this `valid` as do not check rule of moves.
+
+At now, the concept of `legality of the move` is clear. To check Legality of the move,
+you need to check only rule of moves.   
+   
+Now then, `ChessGameSession` is charge to validate `1` only and only if, while
+`Piece` is charge to check `Legality of the move`.
+
+
+
+# `class Chessboard`에 대하여
+
+체스보드는 아래와 같은 계층 구조를 가지고 있습니다.
+
+`class Chessboard`   
+-> `class Piece` (상속받은 클래스 포함)
+
+> 이동이 수행될 때 변경되어야 하는 몇 가지 상태가 있습니다.
+
+그 상태들은 `class Chessboard`와 `class Piece`에 분산되어 있습니다. 하지만, 오직 `class Chessboard`만이 그것들을 관리할 책임이 있습니다. **Pieces**에서는 이것에 대해 걱정할 필요가 없습니다.
+
+> 이동의 유효성 검사
+
+체크해야 할 사항은 두 가지 유형이 있습니다.
+1. 유효한 입력
+2. 이동의 합법성
+
+`유효한 입력`에서의 "유효한 이동"은 일반적인 방식으로 클라이언트의 요청에서 오는 이동입니다.
+예를 들어, 이동의 `startPosition`에 있는 조각을 `P`라고 하면,
+`P`가 이 턴의 플레이어 색과 다르다면, 그 이동은 `유효하지 않음`입니다. 이는 클라이언트의 프로그램이 사용자가 불법적인 이동을 보내지 못하도록 제한하기 때문에 클라이언트가 이 이동 요청을 **절대** 보낼 수 없기 때문입니다.
+동시에, 이 `유효함`을 이동 규칙을 확인하지 않는 것으로 정의합니다.
+
+이제 `이동의 합법성`의 개념이 명확해졌습니다. 이동의 합법성을 확인하려면, 이동 규칙만 확인하면 됩니다.
+
+그러므로, `ChessGameSession`은 오직 `1`만 확인할 책임이 있으며, `Piece`는 `이동의 합법성`을 확인할 책임이 있습니다.

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/README.md
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/README.md
@@ -32,7 +32,7 @@ At same time, I define this `valid` as do not check rule of moves.
 At now, the concept of `legality of the move` is clear. To check Legality of the move,
 you need to check only rule of moves.   
    
-Now then, `ChessGameSession` is charge to validate `1` only and only if, while
+Now then, `Chessboard` is charge to validate `1` only and only if, while
 `Piece` is charge to check `Legality of the move`.
 
 
@@ -61,4 +61,4 @@ Now then, `ChessGameSession` is charge to validate `1` only and only if, while
 
 이제 `이동의 합법성`의 개념이 명확해졌습니다. 이동의 합법성을 확인하려면, 이동 규칙만 확인하면 됩니다.
 
-그러므로, `ChessGameSession`은 오직 `1`만 확인할 책임이 있으며, `Piece`는 `이동의 합법성`을 확인할 책임이 있습니다.
+그러므로, `Chessboard`은 오직 `1`만 확인할 책임이 있으며, `Piece`는 `이동의 합법성`을 확인할 책임이 있습니다.

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Rook.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Rook.java
@@ -77,7 +77,10 @@ public class Rook extends Piece {
         if (diff.col != 0) diff.col /= Math.abs(diff.col);
 
         if (checkPosInDirection(dest, diff)) {
-            chessboard.movePiece(this.position, dest);
+            chessboard.movePiece(new ChessboardMove(
+                    new ChessboardPos(this.position),
+                    new ChessboardPos(dest)
+            ));
             return true;
         }
 

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Rook.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Rook.java
@@ -1,0 +1,86 @@
+package com.example.chessdotnet.service.chessGameSession;
+
+import java.util.LinkedList;
+
+
+/**
+ * Rook class of chess piece
+ */
+public class Rook extends Piece {
+    /**
+     * default constructor
+     *
+     * @param position position in chessboard.
+     * @param pieceColor color (maybe WHITE or BLACK) of this.
+     * @param chessboard chessboard where this piece exists.
+     */
+    public Rook(ChessboardPos position, PieceColor pieceColor, Chessboard chessboard) {
+        super(position, pieceColor, chessboard);
+    }
+
+    /**
+     * return its name(typename of piece)
+     *
+     * @return typename of piece
+     */
+    @Override
+    public String toString() {
+        return "Rook";
+    }
+
+    /**
+     * check is it Empty Square (Not a Piece)
+     * Must be overridden
+     *
+     * @return true if it is empty square
+     */
+    @Override
+    public boolean isEmptySquare() {
+        return false;
+    }
+
+    /**
+     * Get its possible destinations of its legal moves.
+     *
+     * @return LinkedList of ChessboardPos which contains possible destinations of its legal moves.
+     */
+    @Override
+    public LinkedList<ChessboardPos> getDestinations() {
+        LinkedList<ChessboardPos> dests = new LinkedList<>();
+
+        addSquaresInDirection(dests, new ChessboardPos(0, 1));
+        addSquaresInDirection(dests, new ChessboardPos(0, -1));
+        addSquaresInDirection(dests, new ChessboardPos(-1, 0));
+        addSquaresInDirection(dests, new ChessboardPos(-1, 0));
+
+        return dests;
+    }
+
+    /**
+     * update its position and chessboard, if dest is reachable in one move by itself.
+     * It is a safe way to update chessboard, maintaining coherency between `piece.position`
+     * and actual position in chessboard.
+     *
+     * @param dest destination of move to test
+     * @return true if and only if position updated.
+     */
+    @Override
+    public boolean testAndMove(ChessboardPos dest) {
+        /* check if them have same row or col, but not both (XNOR) */
+        if ((dest.row == position.row) == (dest.col == position.col))
+            return false;
+
+        ChessboardPos diff = ChessboardPos.sub(dest, position);
+
+        /* get direction, src to dest */
+        if (diff.row != 0) diff.row /= Math.abs(diff.row);
+        if (diff.col != 0) diff.col /= Math.abs(diff.col);
+
+        if (checkPosInDirection(dest, diff)) {
+            chessboard.movePiece(this.position, dest);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Rook.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Rook.java
@@ -8,20 +8,20 @@ import java.util.LinkedList;
  */
 public class Rook extends Piece {
     /**
-     * default constructor
+     * Default constructor
      *
-     * @param position position in chessboard.
-     * @param pieceColor color (maybe WHITE or BLACK) of this.
-     * @param chessboard chessboard where this piece exists.
+     * @param position Position in chessboard.
+     * @param pieceColor Color (maybe WHITE or BLACK) of this.
+     * @param chessboard Chessboard where this piece exists.
      */
     public Rook(ChessboardPos position, PieceColor pieceColor, Chessboard chessboard) {
         super(position, pieceColor, chessboard);
     }
 
     /**
-     * return its name(typename of piece)
+     * Return its name(typename of piece)
      *
-     * @return typename of piece
+     * @return Typename of piece
      */
     @Override
     public String toString() {
@@ -29,10 +29,10 @@ public class Rook extends Piece {
     }
 
     /**
-     * check is it Empty Square (Not a Piece)
+     * Check is it Empty Square (Not a Piece)
      * Must be overridden
      *
-     * @return true if it is empty square
+     * @return True if it is empty square
      */
     @Override
     public boolean isEmptySquare() {
@@ -57,12 +57,12 @@ public class Rook extends Piece {
     }
 
     /**
-     * update its position and chessboard, if dest is reachable in one move by itself.
+     * Update its position and chessboard, if dest is reachable in one move by itself.
      * It is a safe way to update chessboard, maintaining coherency between `piece.position`
      * and actual position in chessboard.
      *
-     * @param dest destination of move to test
-     * @return true if and only if position updated.
+     * @param dest Destination of move to test
+     * @return True if and only if position updated.
      */
     @Override
     public boolean testAndMove(ChessboardPos dest) {

--- a/src/test/java/com/example/chessdotnet/service/chessGameSession/ChessboardTest.java
+++ b/src/test/java/com/example/chessdotnet/service/chessGameSession/ChessboardTest.java
@@ -1,0 +1,561 @@
+package com.example.chessdotnet.service.chessGameSession;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.util.Pair;
+import org.springframework.util.Assert;
+
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.TreeSet;
+
+public class ChessboardTest {
+
+    /* Algebraic chess notation to ChessboardPos */
+    static public ChessboardPos parsePos(String pos) {
+        int col = (int)(pos.charAt(0) - 'a');
+
+        int row = (int)(pos.charAt(1) - '0');
+        row -= 1;
+        row = 7 - row;
+
+        return new ChessboardPos(row, col);
+    }
+
+    /* Algebraic chess notation(not standard) to ChessboardMove
+     * format is `(src) (dest)` (e.g. e2 e4 )
+     */
+    static public ChessboardMoveForTest parseMove(String move) {
+        return new ChessboardMoveForTest(
+                parsePos(move.substring(0, 2)),
+                parsePos(move.substring(3))
+        );
+    }
+
+    /* Having revertible move method. */
+    static class ChessboardForTest extends Chessboard {
+        public ChessboardForTest() {
+            super();
+        }
+        public boolean tryMoveAndRollback(ChessboardMoveForTest move) {
+            var src = move.startPosition;
+            var dest = move.endPosition;
+
+            Piece srcPiece = getPiece(src);
+            Piece destPiece = getPiece(src);
+            var befo_nullable_lastMoved = nullable_lastMoved;
+
+            var ret = tryMovePiece(new ChessboardMove(src, dest));
+            if (ret) {
+                nullable_lastMoved = befo_nullable_lastMoved;
+                chessboard[src.row][src.col] = srcPiece;
+                chessboard[dest.row][dest.col] = destPiece;
+
+                if (turnNow == Piece.PieceColor.BLACK) {
+                    turnNow = Piece.PieceColor.WHITE;
+                } else {
+                    turnNow = Piece.PieceColor.BLACK;
+                }
+
+                moveRecords.removeLast();
+
+                if (move.isCastling()) {
+                    ChessboardPos castleDirection = ChessboardPos.sub(dest, src);
+                    int colOfRook;
+                    if (castleDirection.col > 0) {
+                        colOfRook = 7;
+                    } else {
+                        colOfRook = 0;
+                    }
+
+                    int rowOfRook = dest.row;
+
+                    ChessboardPos newPosOfRook = new ChessboardPos(
+                            rowOfRook,
+                            castleDirection.col > 0 ? dest.col - 1 : dest.col + 1
+                    );
+
+                    chessboard[rowOfRook][colOfRook] = chessboard[newPosOfRook.row][newPosOfRook.col];
+                    chessboard[rowOfRook][colOfRook].position = new ChessboardPos(rowOfRook, colOfRook);
+                    chessboard[newPosOfRook.row][newPosOfRook.col] = new Piece(
+                            new ChessboardPos(rowOfRook, colOfRook),
+                            Piece.PieceColor.NONE,
+                            this
+                    );
+                }
+
+                if (move.getEnPassantInfo().getFirst()) {
+                    ChessboardPos pawnTaken = move.getEnPassantInfo().getSecond();
+                    chessboard[pawnTaken.row][pawnTaken.col] = new Pawn(
+                            new ChessboardPos(pawnTaken),
+                            (turnNow == Piece.PieceColor.BLACK) ? Piece.PieceColor.WHITE : Piece.PieceColor.BLACK,
+                            this,
+                            (turnNow == Piece.PieceColor.BLACK) ? new ChessboardPos(1, 0) : new ChessboardPos(-1, 0)
+                    );
+                }
+            }
+            return ret;
+        }
+    }
+
+    static class ChessboardMoveForTest extends ChessboardMove {
+        public ChessboardMoveForTest(ChessboardPos src, ChessboardPos dest) { super(src, dest); }
+        public boolean isLegal = true;
+        public ChessboardMoveForTest clearIsLegal() { isLegal = false; return this; }
+    }
+
+    static public void showBoardBrief(Chessboard board, ChessboardPos src, ChessboardPos dest) {
+        System.out.println("[Board state]\n" +
+                "Turn:\t\t\t\t" + board.turnNow.name +
+                "\nLast moved:\t\t\t" + board.nullable_lastMoved.toString() +
+                "\nLast piece:\t\t\t" + board.moveRecords.getLast().toString() +
+                "\nPiece in dest:\t\t" + board.getPiece(dest).toString() +
+                "\nPiece in src:\t\t" + board.getPiece(src).toString() +
+                "\nPassed move count:\t" + board.moveRecords.size()
+        );
+    }
+
+    /* Simulate all moves, checking `isLegal == tryMovePiece` */
+    Chessboard runMoves(LinkedList<ChessboardMoveForTest> moves) {
+        Chessboard board = new Chessboard();
+
+        for (var move : moves) {
+            boolean res = board.tryMovePiece(move);
+            if (move.isLegal != res) {
+                showBoardBrief(board, move.startPosition, move.endPosition);
+                Assert.isTrue(false, res ? "False Positive" : "False Negative");
+            }
+        }
+        return board;
+    }
+
+    /* Comparator for TreeSet<ChessboardMove> */
+    static Comparator<ChessboardMove> moveComparator = new Comparator<ChessboardMove>() {
+        public int compareChessboardPos(ChessboardPos o1, ChessboardPos o2) {
+            if (o1.row != o2.row) return Integer.compare(o1.row, o2.row);
+            else return Integer.compare(o1.col, o2.col);
+        }
+        @Override
+        public int compare(ChessboardMove o1, ChessboardMove o2) {
+            if (!o1.startPosition.equals(o2.startPosition))
+                return compareChessboardPos(o1.startPosition, o2.startPosition);
+            else
+                return compareChessboardPos(o1.endPosition, o2.endPosition);
+        }
+    };
+
+
+
+    @Test
+    void testMovesFromInitial() {
+        TreeSet<ChessboardMove> whiteLegalMoves = new TreeSet<>(moveComparator);
+        TreeSet<ChessboardMove> blackLegalMoves = new TreeSet<>(moveComparator);
+
+        /* Pawn lines */
+        for (int c = 0; c < 8; c++) {
+            ChessboardMove move = new ChessboardMove(
+                    new ChessboardPos(1, c),
+                    new ChessboardPos(2, c)
+            );
+            blackLegalMoves.add(move);
+
+            move = new ChessboardMove(
+                    new ChessboardPos(1, c),
+                    new ChessboardPos(3, c)
+            );
+            blackLegalMoves.add(move);
+        }
+
+        for (int c = 0; c < 8; c++) {
+            ChessboardMove move = new ChessboardMove(
+                    new ChessboardPos(6, c),
+                    new ChessboardPos(5, c)
+            );
+            whiteLegalMoves.add(move);
+
+            move = new ChessboardMove(
+                    new ChessboardPos(6, c),
+                    new ChessboardPos(4, c)
+            );
+            whiteLegalMoves.add(move);
+        }
+
+        /* Knight 1 */
+        blackLegalMoves.add(new ChessboardMove(
+                new ChessboardPos(0, 1),
+                new ChessboardPos(2, 0)
+        ));
+        blackLegalMoves.add(new ChessboardMove(
+                new ChessboardPos(0, 1),
+                new ChessboardPos(2, 2)
+        ));
+
+        /* Knight 2 */
+        blackLegalMoves.add(new ChessboardMove(
+                new ChessboardPos(0, 6),
+                new ChessboardPos(2, 7)
+        ));
+        blackLegalMoves.add(new ChessboardMove(
+                new ChessboardPos(0, 6),
+                new ChessboardPos(2, 5)
+        ));
+
+        /* Knight 3 */
+        whiteLegalMoves.add(new ChessboardMove(
+                new ChessboardPos(7, 1),
+                new ChessboardPos(5, 0)
+        ));
+        whiteLegalMoves.add(new ChessboardMove(
+                new ChessboardPos(7, 1),
+                new ChessboardPos(5, 2)
+        ));
+
+        /* Knight 4 */
+        whiteLegalMoves.add(new ChessboardMove(
+                new ChessboardPos(7, 6),
+                new ChessboardPos(5, 5)
+        ));
+        whiteLegalMoves.add(new ChessboardMove(
+                new ChessboardPos(7, 6),
+                new ChessboardPos(5, 7)
+        ));
+
+
+        /* for all squares, start and destinations */
+        for (int sr = 0; sr < 8; sr++) {
+            for (int sc = 0; sc < 8; sc++) {
+                for (int dr = 0; dr < 8; dr++) {
+                    for (int dc = 0; dc < 8; dc++) {
+                        ChessboardForTest board = new ChessboardForTest();
+                        ChessboardPos src = new ChessboardPos(sr, sc);
+                        ChessboardPos dest = new ChessboardPos(dr, dc);
+                        ChessboardMove move = new ChessboardMove(src, dest);
+                        if (board.tryMovePiece(new ChessboardMove(src, dest))) {
+                            Assert.isTrue(whiteLegalMoves.contains(move),
+                                    String.format("[%d,%d]-[%d,%d] False Positive at white turn",
+                                            sr, sc, dr, dc));
+                        } else {
+                            Assert.isTrue(!whiteLegalMoves.contains(move),
+                                    String.format("[%d,%d]-[%d,%d] False Negative at white turn",
+                                            sr, sc, dr, dc));
+                        }
+                    }
+                }
+            }
+        }
+
+
+
+        /* for all squares, start and destinations */
+        for (int sr = 0; sr < 8; sr++) {
+            for (int sc = 0; sc < 8; sc++) {
+                for (int dr = 0; dr < 8; dr++) {
+                    for (int dc = 0; dc < 8; dc++) {
+                        ChessboardPos src = new ChessboardPos(sr, sc);
+                        ChessboardPos dest = new ChessboardPos(dr, dc);
+                        ChessboardMove move = new ChessboardMove(src, dest);
+                        ChessboardForTest blackTurn = new ChessboardForTest();
+                        blackTurn.turnNow = Piece.PieceColor.BLACK;
+                        if (blackTurn.tryMovePiece(new ChessboardMove(src, dest))) {
+                            if (!blackLegalMoves.contains(move))
+                                System.out.println("board state\n" +
+                                        "Turn:\t\t\t" + blackTurn.turnNow.name +
+                                        "\nlast moved:\t\t" + blackTurn.nullable_lastMoved.toString() +
+                                        "\nlast piece:\t\t" + blackTurn.moveRecords.getLast().toString() +
+                                        "\npiece in dest:\t" + blackTurn.getPiece(dest).toString() +
+                                        "\npiece in src:\t" + blackTurn.getPiece(src).toString());
+                            Assert.isTrue(blackLegalMoves.contains(move),
+                                    String.format("[%d,%d]-[%d,%d] False Positive at black turn",
+                                            sr, sc, dr, dc));
+                        } else {
+                            if (blackLegalMoves.contains(move))
+                                System.out.println("board state\n" +
+                                        "Turn:\t\t\t" + blackTurn.turnNow.name +
+                                        "\nlast moved:\t\t" + blackTurn.nullable_lastMoved.toString() +
+                                        "\nlast piece:\t\t" + blackTurn.moveRecords.getLast().toString() +
+                                        "\npiece in dest:\t" + blackTurn.getPiece(dest).toString() +
+                                        "\npiece in src:\t" + blackTurn.getPiece(src).toString());
+                            Assert.isTrue(!blackLegalMoves.contains(move),
+                                    String.format("[%d,%d]-[%d,%d] False Negative at black turn",
+                                            sr, sc, dr, dc));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+
+    @Test
+    void kingSideCastlingLegal() {
+        LinkedList<ChessboardMoveForTest> moves = new LinkedList<>();
+
+        moves.add(parseMove("e2 e4"));
+        moves.add(parseMove("e7 e5"));
+        moves.add(parseMove("g1 f3"));
+        moves.add(parseMove("b8 c6"));
+        moves.add(parseMove("f1 c4"));
+        moves.add(parseMove("f8 c5"));
+        moves.add(parseMove("e1 g1"));
+        moves.add(parseMove("g8 f6"));
+        moves.add(parseMove("f1 e1"));
+        runMoves(moves);
+    }
+
+    @Test
+    void kingSideCastlingIllegal_ThreatOnWay() {
+        LinkedList<ChessboardMoveForTest> moves = new LinkedList<>();
+
+        moves.add(parseMove("e2 e4"));
+        moves.add(parseMove("d7 d5"));
+        moves.add(parseMove("f1 a6"));
+        moves.add(parseMove("d8 d6"));
+        moves.add(parseMove("g1 f3"));
+        moves.add(parseMove("d6 a6"));
+        moves.add(parseMove("e1 g1").clearIsLegal());
+        runMoves(moves);
+    }
+
+    @Test
+    void kingSideCastlingIllegal_KingMoved() {
+        LinkedList<ChessboardMoveForTest> moves = new LinkedList<>();
+
+        moves.add(parseMove("e2 e4"));
+        moves.add(parseMove("d7 d5"));
+        moves.add(parseMove("f1 a6"));
+        moves.add(parseMove("d8 d6"));
+        moves.add(parseMove("g1 f3"));
+        moves.add(parseMove("d6 h6"));
+        moves.add(parseMove("e1 e2"));
+        moves.add(parseMove("h6 d6"));
+        moves.add(parseMove("e2 e1"));
+        moves.add(parseMove("d6 d8"));
+        moves.add(parseMove("e1 g1").clearIsLegal());
+        runMoves(moves);
+    }
+
+    @Test
+    void kingSideCastlingIllegal_RookMoved() {
+        LinkedList<ChessboardMoveForTest> moves = new LinkedList<>();
+
+        moves.add(parseMove("e2 e4"));
+        moves.add(parseMove("d7 d5"));
+        moves.add(parseMove("f1 a6"));
+        moves.add(parseMove("d8 d6"));
+        moves.add(parseMove("g1 f3"));
+        moves.add(parseMove("d6 h6"));
+        moves.add(parseMove("h1 g1"));
+        moves.add(parseMove("h6 d6"));
+        moves.add(parseMove("g1 h1"));
+        moves.add(parseMove("d6 d8"));
+        moves.add(parseMove("e1 g1").clearIsLegal());
+        runMoves(moves);
+    }
+
+    @Test
+    void queenSideCastlingLegal() {
+        LinkedList<ChessboardMoveForTest> moves = new LinkedList<>();
+
+        moves.add(parseMove("d2 d4"));
+        moves.add(parseMove("d7 d5"));
+        moves.add(parseMove("c1 h6"));
+        moves.add(parseMove("g8 h6"));
+        moves.add(parseMove("b1 c3"));
+        moves.add(parseMove("d8 d6"));
+        moves.add(parseMove("d1 d3"));
+        moves.add(parseMove("d6 g6"));
+        moves.add(parseMove("e1 c1"));
+        moves.add(parseMove("g6 d6"));
+        moves.add(parseMove("d1 d2"));
+        runMoves(moves);
+    }
+
+    @Test
+    void queenSideCastlingIllegal_ThreatOnWay() {
+        LinkedList<ChessboardMoveForTest> moves = new LinkedList<>();
+
+        moves.add(parseMove("d2 d4"));
+        moves.add(parseMove("d7 d5"));
+        moves.add(parseMove("c1 h6"));
+        moves.add(parseMove("g8 h6"));
+        moves.add(parseMove("b1 c3"));
+        moves.add(parseMove("d8 d6"));
+        moves.add(parseMove("d1 d3"));
+        moves.add(parseMove("d6 f4"));
+        moves.add(parseMove("e1 c1").clearIsLegal());
+        runMoves(moves);
+    }
+
+    @Test
+    void enPassantLegal() {
+        LinkedList<ChessboardMoveForTest> moves = new LinkedList<>();
+
+        moves.add(parseMove("e2 e4"));
+        moves.add(parseMove("b8 c6"));
+        moves.add(parseMove("e4 e5"));
+        moves.add(parseMove("d7 d5"));
+        moves.add(parseMove("e5 d6"));
+
+        runMoves(moves);
+    }
+
+    @Test
+    void enPassantIllegal_NoTarget() {
+        LinkedList<ChessboardMoveForTest> moves = new LinkedList<>();
+
+        moves.add(parseMove("e2 e4"));
+        moves.add(parseMove("b8 c6"));
+        moves.add(parseMove("e4 e5"));
+        moves.add(parseMove("c6 b8"));
+        moves.add(parseMove("e5 d6").clearIsLegal());
+        runMoves(moves);
+
+        /* Another Case: target is already moved */
+        moves = new LinkedList<>();
+
+        moves.add(parseMove("e2 e4"));
+        moves.add(parseMove("b8 c6"));
+        moves.add(parseMove("e4 e5"));
+        moves.add(parseMove("d7 d5"));
+        moves.add(parseMove("g1 f3"));
+        moves.add(parseMove("d5 d4"));
+        moves.add(parseMove("e5 d6").clearIsLegal());
+    }
+
+    @Test
+    void enPassantIllegal_TooLate() {
+        LinkedList<ChessboardMoveForTest> moves = new LinkedList<>();
+
+        moves.add(parseMove("e2 e4"));
+        moves.add(parseMove("b8 c6"));
+        moves.add(parseMove("e4 e5"));
+        moves.add(parseMove("d7 d5"));
+        moves.add(parseMove("g1 f3"));
+        moves.add(parseMove("c6 b8"));
+        moves.add(parseMove("e5 d6").clearIsLegal());
+        runMoves(moves);
+    }
+
+    @Test
+    void moveIllegal_NotKingInCheck() {
+        LinkedList<ChessboardMoveForTest> moves = new LinkedList<>();
+
+        moves.add(parseMove("e2 e4"));
+        moves.add(parseMove("e7 e5"));
+        moves.add(parseMove("d1 h5"));
+        moves.add(parseMove("g8 f6"));
+        moves.add(parseMove("h5 e5"));
+        moves.add(parseMove("f6 g4").clearIsLegal());
+        runMoves(moves);
+    }
+
+    @Test
+    void moveLegal_blockCheck() {
+        LinkedList<ChessboardMoveForTest> moves = new LinkedList<>();
+
+        moves.add(parseMove("e2 e4"));
+        moves.add(parseMove("e7 e5"));
+        moves.add(parseMove("d1 h5"));
+        moves.add(parseMove("g8 f6"));
+        moves.add(parseMove("h5 e5"));
+        moves.add(parseMove("f8 e7"));
+        runMoves(moves);
+    }
+
+    @Test
+    void moveLegal_evadeCheck() {
+        LinkedList<ChessboardMoveForTest> moves = new LinkedList<>();
+
+        moves.add(parseMove("e2 e4"));
+        moves.add(parseMove("e7 e5"));
+        moves.add(parseMove("d1 h5"));
+        moves.add(parseMove("d7 d5"));
+        moves.add(parseMove("h5 e5"));
+        moves.add(parseMove("e8 d7"));
+        runMoves(moves);
+    }
+
+    /* Check the promotion properly reverted  */
+    @Test
+    void moveILLegal_noEvadeCheckButPromotion() {
+        LinkedList<ChessboardMoveForTest> moves = new LinkedList<>();
+
+        moves.add(parseMove("d2 d4"));
+        moves.add(parseMove("c7 c5"));
+        moves.add(parseMove("d4 c5"));
+        moves.add(parseMove("d7 d5"));
+        moves.add(parseMove("c5 c6"));
+        moves.add(parseMove("e7 e5"));
+        moves.add(parseMove("c6 b7"));
+        moves.add(parseMove("d8 a5"));
+        /* Try promotion in check (It does not resolve check, so will be reverted) */
+        moves.add(((ChessboardMoveForTest) parseMove("b7 c8").
+                setPromotionToWhat(Piece.PieceType.QUEEN)).
+                clearIsLegal());
+        /* Some illegal moves if reverting was successful */
+        moves.add(parseMove("b7 b4").clearIsLegal());
+        moves.add(parseMove("a5 c5").clearIsLegal());
+        moves.add(parseMove("c8 c3").clearIsLegal());
+
+        /* Blocking check is successful if reverted */
+        moves.add(parseMove("c1 d2"));
+        runMoves(moves);
+    }
+
+    @Test
+    void moveILLegal_noEvadeCheck() {
+        LinkedList<ChessboardMoveForTest> moves = new LinkedList<>();
+
+        moves.add(parseMove("e2 e4"));
+        moves.add(parseMove("f7 f5"));
+        moves.add(parseMove("e4 f5"));
+        moves.add(parseMove("g7 g6"));
+        moves.add(parseMove("f5 g6"));
+        moves.add(parseMove("f8 h6"));
+        moves.add(parseMove("g6 g7"));
+        moves.add(parseMove("g8 f6"));
+        moves.add((ChessboardMoveForTest)(parseMove("g7 h8").setPromotionToWhat(Piece.PieceType.QUEEN)));
+        moves.add(parseMove("e8 f8").clearIsLegal());
+        moves.add(parseMove("h6 f8"));
+        runMoves(moves);
+    }
+
+    @Test
+    void moveLegal_takePieceChecking() {
+        LinkedList<ChessboardMoveForTest> moves = new LinkedList<>();
+
+        moves.add(parseMove("e2 e4"));
+        moves.add(parseMove("f7 f5"));
+        moves.add(parseMove("e4 f5"));
+        moves.add(parseMove("g7 g6"));
+        moves.add(parseMove("f5 g6"));
+        moves.add(parseMove("f8 h6"));
+        moves.add(parseMove("g6 g7"));
+        moves.add(parseMove("g8 f6"));
+        moves.add(parseMove("g1 f3"));
+        moves.add(parseMove("h8 f8"));
+        moves.add((ChessboardMoveForTest)(parseMove("g7 f8").setPromotionToWhat(Piece.PieceType.QUEEN)));
+        moves.add(parseMove("e8 f8"));
+        runMoves(moves);
+    }
+
+    /* Make itself to be checked by itself */
+    @Test
+    void moveIllegal_vulnerableItself() {
+        LinkedList<ChessboardMoveForTest> moves = new LinkedList<>();
+
+        moves.add(parseMove("e2 e4"));
+        moves.add(parseMove("f7 f5"));
+        moves.add(parseMove("e4 f5"));
+        moves.add(parseMove("g7 g6"));
+        moves.add(parseMove("f5 g6"));
+        moves.add(parseMove("f8 h6"));
+        moves.add(parseMove("g6 g7"));
+        moves.add(parseMove("g8 f6"));
+        moves.add(parseMove("g1 f3"));
+        moves.add(parseMove("h8 f8"));
+        moves.add((ChessboardMoveForTest)(parseMove("g7 g8").setPromotionToWhat(Piece.PieceType.ROOK)));
+        moves.add(parseMove("f8 f7").clearIsLegal());
+        runMoves(moves);
+    }
+}

--- a/src/test/java/com/example/chessdotnet/service/chessGameSession/ChessboardTest.md
+++ b/src/test/java/com/example/chessdotnet/service/chessGameSession/ChessboardTest.md
@@ -1,0 +1,8 @@
+# Test Design for Chessboard
+   
+1. 최초의 보드 상태에서 모든 move 테스트
+   - 가능한 모든 `Piece::testAndMove()` 호출
+        1. 시작 포지션에서 모든 경우의 수 `시작 위치 X 도착 위치` 64 * 64개 호출
+        2. 이때 가능한 legal 인 경우의 수는 오직 폰의 1~2칸 전진 + 나이트 움직임이다.
+        3. 어떤 move 가 legal 인지 판단하기 위해서 2번의 Move 들은 특별히 TreeSet 에 저장한다.
+        4. 첫 턴에서 white 가 legal 인 수를 둔 다음 black 의 턴에 동일하게 1번을 테스트.

--- a/src/test/java/com/example/chessdotnet/service/chessGameSession/ChessboardTest.md
+++ b/src/test/java/com/example/chessdotnet/service/chessGameSession/ChessboardTest.md
@@ -5,4 +5,20 @@
         1. 시작 포지션에서 모든 경우의 수 `시작 위치 X 도착 위치` 64 * 64개 호출
         2. 이때 가능한 legal 인 경우의 수는 오직 폰의 1~2칸 전진 + 나이트 움직임이다.
         3. 어떤 move 가 legal 인지 판단하기 위해서 2번의 Move 들은 특별히 TreeSet 에 저장한다.
-        4. 첫 턴에서 white 가 legal 인 수를 둔 다음 black 의 턴에 동일하게 1번을 테스트.
+        4. 첫 턴에서 white 가 legal 인 수를 둔 다음 black 의 턴에 동일하게 1번을 테스트.   
+        
+
+2. 이외의 테스트 케이스들
+   - 일부 테스트 케이스들이 있습니다.
+   - 각 테스트 케이스에 대한 자세한 설명은 필요하면 나중에 적겠습니다.
+
+3. 일부 함수들의 간략한 설명
+   - `parsePos()`: 대수 표기법에 따른 좌표 하나를 받아서 ChessboardPos 하나를 생성합니다.
+   - `parseMove()`: 대수 표기법에 따른 좌표 두 개를 받아서 `ChessboardMoveForTest` 하나를 생성합니다.
+   - `ChessboardForTest`: `tryMoveAndRollback` 메소드가 추가되어있습니다.
+     - `tryMoveAndRollback`: `tryMovePiece` 와 동일한 값을 반환하지만, 성공하더라도 chessboard 에는 반영되지 않습니다. (롤백됩니다.)
+   - `ChessboardMoveForTest`: 저장된 `move` 의 legal 여부를 마킹할 수 있습니다.
+     - `clearIsLegal()`: `isLegal = false;` 로 처리한 후, 자기 자신을 반환합니다. (Fluent Interface)
+   - `showBoardBrief()`: 주어진 `Chessboard`와 두 좌표로 현재 게임 상태를 간략하게 출력합니다.
+   - `runMoves()`: `ChessboardMoveForTest` 의 리스트를 받고 시뮬레이션합니다. `tryMovePiece()` 의 결과가 
+   각 move 의 `isLegal` 과 일치하는지 확인합니다. 


### PR DESCRIPTION
### PR 설명
앞으로 추가할 기물 이동 웹소켓 API 를 위한 필요 작업입니다.

1. **모든 이동 규칙 추가**:
    - 앙파상, 캐슬링, promotion 을 포함한 모든 이동 규칙이 포함되어있습니다.
   
2. **기보 기억**

    - 움직임 정보를 정보의 누락없이 기억합니다.
   
4. **관련 테스트 코드 추가**
    - 많은 케이스를 커버합니다.

### 관련 이슈
- close #15
- close #16
- close #17
- close #18 

### 테스트 과정
- #18 을 참고해주세요.

### 추가 설명
- 아직 체크메이트 검증이 되지 않고 있습니다.
- 스테일메이트 같은 로직또한 아직입니다.