### PR TITLE
[Fix] `RoomDTO`: Fix wrong path to RoomDTO (#34 #35)

### DIFF
--- a/src/main/java/com/example/chessdotnet/dto/RoomStatusMessage.java
+++ b/src/main/java/com/example/chessdotnet/dto/RoomStatusMessage.java
@@ -1,5 +1,6 @@
 package com.example.chessdotnet.dto;
 
+import com.example.chessdotnet.dto.Room.RoomDTO;
 import lombok.Data;
 
 /**

--- a/src/main/java/com/example/chessdotnet/service/RoomWebSocketService.java
+++ b/src/main/java/com/example/chessdotnet/service/RoomWebSocketService.java
@@ -1,6 +1,6 @@
 package com.example.chessdotnet.service;
 
-import com.example.chessdotnet.dto.RoomDTO;
+import com.example.chessdotnet.dto.Room.RoomDTO;
 import com.example.chessdotnet.dto.RoomStatusMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;


### PR DESCRIPTION
### 작업 내용
`import com.example.chessdotnet.dto.RoomDTO;` 로 되어있는 경로를
`import com.example.chessdotnet.dto.Room.RoomDTO;` 로 수정하였습니다.