### PR TITLE
[Feature/Fix] Add methods for `Chessboard` class to determine checkmate and stalemate or else. / 유효하지 않은 promotion 을 판별하지 못하던 오류 수정

### DIFF
--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Chessboard.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Chessboard.java
@@ -255,6 +255,111 @@ public class Chessboard {
     }
 
     /**
+     * Only check is this move legal by call `Chessboard::tryMovePiece`.
+     * After try to move, rollback it.
+     *
+     * @param move
+     * @return
+     */
+    public boolean tryMoveAndRollback(ChessboardMove move) {
+        var src = move.startPosition;
+        var dest = move.endPosition;
+
+        Piece srcPiece = getPiece(src);
+        Piece destPiece = getPiece(src);
+        var befo_nullable_lastMoved = nullable_lastMoved;
+
+        boolean moveRes = tryMovePiece(move);
+
+        if (moveRes) {
+            nullable_lastMoved = befo_nullable_lastMoved;
+            chessboard[src.row][src.col] = srcPiece;
+            chessboard[dest.row][dest.col] = destPiece;
+
+            if (turnNow == Piece.PieceColor.BLACK) {
+                turnNow = Piece.PieceColor.WHITE;
+            } else {
+                turnNow = Piece.PieceColor.BLACK;
+            }
+
+            moveRecords.removeLast();
+
+            if (move.isCastling()) {
+                ChessboardPos castleDirection = ChessboardPos.sub(dest, src);
+                int colOfRook;
+                if (castleDirection.col > 0) {
+                    colOfRook = 7;
+                } else {
+                    colOfRook = 0;
+                }
+
+                int rowOfRook = dest.row;
+
+                ChessboardPos newPosOfRook = new ChessboardPos(
+                        rowOfRook,
+                        castleDirection.col > 0 ? dest.col - 1 : dest.col + 1
+                );
+
+                chessboard[rowOfRook][colOfRook] = chessboard[newPosOfRook.row][newPosOfRook.col];
+                chessboard[rowOfRook][colOfRook].position = new ChessboardPos(rowOfRook, colOfRook);
+                chessboard[newPosOfRook.row][newPosOfRook.col] = new Piece(
+                        new ChessboardPos(rowOfRook, colOfRook),
+                        Piece.PieceColor.NONE,
+                        this
+                );
+            }
+
+            if (move.getEnPassantInfo().getFirst()) {
+                ChessboardPos pawnTaken = move.getEnPassantInfo().getSecond();
+                chessboard[pawnTaken.row][pawnTaken.col] = new Pawn(
+                        new ChessboardPos(pawnTaken),
+                        (turnNow == Piece.PieceColor.BLACK) ? Piece.PieceColor.WHITE : Piece.PieceColor.BLACK,
+                        this,
+                        (turnNow == Piece.PieceColor.BLACK) ? new ChessboardPos(1, 0) : new ChessboardPos(-1, 0)
+                );
+            }
+        }
+        return moveRes;
+    }
+
+    /**
+     * Check is king checked in this turn.
+     *
+     * @return true if the king of this turn checked, false otherwise.
+     */
+    public boolean isCheckNow() {
+        var kingToTest = turnNow == Piece.PieceColor.BLACK ? blackKing : whiteKing;
+        return kingToTest.checked();
+    }
+
+    /**
+     * Check is there any legal move in this turn.
+     *
+     * @return true if any legal move exists, false otherwise.
+     */
+    public boolean hasAnyLegalMove() {
+        // for all pieces on board
+        for (int r = 0; r < 8; r++) {
+            for (int c = 0; c < 8; c++) {
+                // pieces having color of this turn
+                if (!chessboard[r][c].isEmptySquare() && chessboard[r][c].pieceColor == turnNow) {
+                    var validDestinations = chessboard[r][c].getDestinations();
+                    for (var dest : validDestinations) {
+                        ChessboardMove move = new ChessboardMove(new ChessboardPos(r, c), dest);
+                        if (chessboard[r][c].toString().equals(Piece.PieceType.PAWN.name) && (r == 7 || r == 0)) {
+                            move.setPromotionToWhat(Piece.PieceType.QUEEN);
+                        }
+                        if (tryMoveAndRollback(move)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
      * Constructor to generate initial state of chessboard
      */
     public Chessboard() {

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Chessboard.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Chessboard.java
@@ -183,15 +183,20 @@ public class Chessboard {
 
         boolean ret;
         if (move.getPromotionInfo().getFirst()) {
-            switch (move.getPromotionInfo().getSecond()) {
-                case QUEEN :
-                case ROOK :
-                case BISHOP :
-                case KNIGHT :
-                    ret = ((Pawn)getPiece(move.startPosition)).testAndMovePromotion(move);
-                    break;
-                default:
-                    ret =  false;
+            // Promotion is requested but it was not pawn
+            if (!getPiece(move.startPosition).toString().equals(Piece.PieceType.PAWN.name)) {
+                ret = false;
+            } else {
+                switch (move.getPromotionInfo().getSecond()) {
+                    case QUEEN:
+                    case ROOK:
+                    case BISHOP:
+                    case KNIGHT:
+                        ret = ((Pawn) getPiece(move.startPosition)).testAndMovePromotion(move);
+                        break;
+                    default:
+                        ret = false;
+                }
             }
         } else
             ret = getPiece(move.startPosition).testAndMove(move.endPosition);

--- a/src/main/java/com/example/chessdotnet/service/chessGameSession/Pawn.java
+++ b/src/main/java/com/example/chessdotnet/service/chessGameSession/Pawn.java
@@ -153,7 +153,7 @@ public class Pawn extends Piece {
      */
     public boolean testAndMovePromotion(ChessboardMove move) {
         Assert.isTrue(move.getPromotionInfo().getFirst(), "Need to have promotion info");
-        if (isLegalMove(move.endPosition)) {
+        if ((move.endPosition.row == 0 || move.endPosition.row == 7) && isLegalMove(move.endPosition)) {
             chessboard.movePiece(move);
             return true;
         }

--- a/src/test/java/com/example/chessdotnet/service/chessGameSession/ChessboardTest.java
+++ b/src/test/java/com/example/chessdotnet/service/chessGameSession/ChessboardTest.java
@@ -574,4 +574,18 @@ public class ChessboardTest {
         moves.add((ChessboardMoveForTest)(parseMove("g1 f3").clearIsLegal().setPromotionToWhat(Piece.PieceType.QUEEN)));
         runMoves(moves);
     }
+
+    @Test
+    void moveLegal_checkIsItCheckmate() {
+        LinkedList<ChessboardMoveForTest> moves = new LinkedList<>();
+
+        moves.add(parseMove("e2 e4"));
+        moves.add(parseMove("f7 f6"));
+        moves.add(parseMove("f1 c4"));
+        moves.add(parseMove("g7 g5"));
+        moves.add(parseMove("d1 h5"));
+        var boardAfterMoves = runMoves(moves);
+        Assert.isTrue(boardAfterMoves.isCheckNow(), "IsCheck: False Negative");
+        Assert.isTrue(!boardAfterMoves.hasAnyLegalMove(), "hasLegalMove: False Negative");
+    }
 }

--- a/src/test/java/com/example/chessdotnet/service/chessGameSession/ChessboardTest.java
+++ b/src/test/java/com/example/chessdotnet/service/chessGameSession/ChessboardTest.java
@@ -558,4 +558,20 @@ public class ChessboardTest {
         moves.add(parseMove("f8 f7").clearIsLegal());
         runMoves(moves);
     }
+
+    @Test
+    void moveIllegal_promotionNotOnLastRank() {
+        LinkedList<ChessboardMoveForTest> moves = new LinkedList<>();
+
+        moves.add((ChessboardMoveForTest)(parseMove("e2 e4").clearIsLegal().setPromotionToWhat(Piece.PieceType.QUEEN)));
+        runMoves(moves);
+    }
+
+    @Test
+    void moveIllegal_promotionFromNotPawn() {
+        LinkedList<ChessboardMoveForTest> moves = new LinkedList<>();
+
+        moves.add((ChessboardMoveForTest)(parseMove("g1 f3").clearIsLegal().setPromotionToWhat(Piece.PieceType.QUEEN)));
+        runMoves(moves);
+    }
 }


### PR DESCRIPTION
### 작업 내용
- 유효하지 않은 promotion 요청을 판별하지 못하던 오류 수정 (b859afe)
- 체크메이트 / 스테일메이트 여부를 판별하기 위한 `Chessboard::isCheckNow`, `Chessboard::hasAnyLegalMove` 메소드 추가